### PR TITLE
docs: design for `sc perms review --all`

### DIFF
--- a/.github/workflows/nix.yml
+++ b/.github/workflows/nix.yml
@@ -1,4 +1,4 @@
-name: Build and publish to FlakeHub
+name: Build
 
 on:
   push:

--- a/.github/workflows/nix.yml
+++ b/.github/workflows/nix.yml
@@ -19,8 +19,6 @@ jobs:
         include:
           - os: ubuntu-22.04
             system: x86_64-linux
-          - os: macos-14
-            system: x86_64-darwin
           - os: macos-15
             system: aarch64-darwin
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/nix.yml
+++ b/.github/workflows/nix.yml
@@ -3,10 +3,10 @@ name: Build and publish to FlakeHub
 on:
   push:
     branches:
-      - main
+      - master
   pull_request:
     branches:
-      - main
+      - master
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -36,7 +36,7 @@ jobs:
       - run: nix build
 
   flakehub-publish:
-    if: github.ref == 'refs/heads/main'
+    if: github.ref == 'refs/heads/master'
     needs: build
     runs-on: ubuntu-latest
     permissions:

--- a/docs/plans/2026-04-06-perms-review-all-design.md
+++ b/docs/plans/2026-04-06-perms-review-all-design.md
@@ -1,0 +1,161 @@
+# Design: `sc perms review --all`
+
+## Problem
+
+`sc perms review` today operates on a single worktree: it resolves the repo and
+branch from cwd (or `--worktree-dir`), loads that one session's tool-use log,
+and lets the user promote rules to the global or repo tier. There is no way to
+review permissions across multiple sessions or repos in one pass, so accumulated
+noise from many historical worktrees has to be reviewed one at a time --- or, in
+practice, never.
+
+We want an `--all` mode that:
+
+- Merges rules from every log in `$XDG_LOG_HOME/spinclass/tool-uses/` across all
+  repos and all branches.
+- Offers only `global | keep | discard` for each rule. The `repo` action is
+  dropped because there is no single repo context when reviewing across repos.
+- Is mutually exclusive with the `[worktree-path]` positional arg and
+  `--worktree-dir`.
+- Still honors `--dry-run`.
+
+## Approach
+
+### 1. Log discovery
+
+New helper:
+
+``` go
+func DiscoverToolUseLogs() ([]string, error)
+```
+
+Walks the flat `tool-uses/` dir and returns every `*.jsonl` path. We do **not**
+need to reverse-parse `<repo>--<branch>.jsonl` back into repo/branch for rule
+merging --- we concatenate and dedupe. That sidesteps the ambiguity of `--` in
+branch names.
+
+### 2. Exclusion logic
+
+`ComputeReviewableRules` currently excludes:
+
+- global Claude settings --- still applies
+- repo-specific tier rules --- can't scope across all repos (see Q1)
+- `Read($HOME/.claude/*)` --- still applies
+- `Read/Edit/Write($worktreePath/*)` --- no single worktree (see Q2)
+
+New function:
+
+``` go
+func ComputeReviewableRulesAll(tiersDir, globalSettingsPath string) ([]string, error)
+```
+
+Proposed behavior:
+
+- Load rules from **every** log in `DiscoverToolUseLogs()`, union + dedupe.
+- Exclude rules in the global Claude settings file.
+- Exclude rules in the global tier (`global.json`).
+- **Do not** exclude per-repo tiers --- a rule already in `repos/A.json` is
+  still a legitimate candidate for global promotion when it appears in repo B's
+  log.
+- Exclude `Read($HOME/.claude/*)`.
+- Worktree-scoped exclusions: see Q2 below.
+
+### 3. Editor content
+
+`FormatEditorContent` today writes `# Repo: %s` and defaults every rule to
+`discard`. For `--all`:
+
+- Header becomes `# All sessions (global promotion only)` with a note that
+  `repo` is not a valid action.
+- Same `discard` default.
+- Optionally (Q3): trailing `# seen in: repoA, repoB` comment per rule to
+  preserve origin context. `ParseEditorContent` already strips trailing `#`
+  comments, so no parser changes needed.
+
+### 4. Decision validation
+
+In `--all`, reject `ReviewPromoteRepo` after parsing:
+
+``` go
+for _, d := range decisions {
+    if d.Action == ReviewPromoteRepo {
+        return fmt.Errorf("line %q: 'repo' action is not allowed with --all", d.Rule)
+    }
+}
+```
+
+Loop back to the editor on failure, matching the existing parse-error path.
+
+### 5. `RouteDecisions` / `DryRunDecisions`
+
+These take a `repo` string today, used only for the repo-tier path. In `--all`,
+`repo` is unused and any `ReviewPromoteRepo` would already have been rejected in
+step 4, so we pass `""`. No signature change, though an assertion at the top of
+`RouteDecisions` (`if repo == "" && any decision is ReviewPromoteRepo, panic`)
+would catch regressions.
+
+### 6. Cmd wiring
+
+``` go
+cmd.Flags().BoolVar(&all, "all", false,
+    "review across all sessions; only global promotion allowed")
+```
+
+Branch in `RunE`: when `--all` is set, call a new `RunReviewEditorAll(dryRun)`
+that skips worktree/repo/branch detection entirely and uses
+`ComputeReviewableRulesAll`. Reject combination with `[worktree-path]` or
+`--worktree-dir` up front.
+
+## Open questions
+
+1.  **Worktree-noise strategy.** Without a single worktree path, rules like
+    `Read(/home/.../worktrees/foo/src/main.go)` will appear in the review.
+    Options:
+
+    - **(a) Accept the noise.** These rules are almost always `discard` anyway.
+      Cheapest path.
+    - **(b) Per-log exclusions.** For each log, derive the worktree path
+      (reverse-parse filename, or look up session state in
+      `~/.local/state/spinclass/sessions/`), filter that log's rules against its
+      own worktree path, then union. More correct, more moving parts.
+    - **(c) Heuristic glob.** Exclude anything matching
+      `Read/Edit/Write(*/.worktrees/*/*)`. Catches the common case cheaply.
+
+    Lean: start with (a), escalate to (b) if the noise is bad in practice.
+
+2.  **Repo tier exclusions.** Confirm the proposal: `--all` excludes only the
+    global tier, not per-repo tiers. Rationale: a rule in `repos/A.json` is
+    handled for A but may still be worth promoting to global when seen from B.
+
+3.  **Origin comments.** Track origin sessions per rule and emit
+    `# seen in: repoA, repoB` trailing comments? Cost is \~10 lines; benefit is
+    context for judging whether a rule is global-worthy.
+
+4.  **Flag name.** `--all` is slightly ambiguous ("all what?"). Alternatives:
+    `--all-sessions`, `--merge-all`. Current lean: `--all` with clear help text.
+
+5.  **Scope creep.** Should `--all` support a filter like `--since <duration>`
+    to only review recent logs? Proposal: no, separate issue.
+
+## Out of scope
+
+- Deleting or pruning logs after review.
+- Per-repo bulk review (all sessions within a single repo). If wanted, follow-up
+  as `--repo <name>`.
+- Any change to `sc perms check`, `list`, or `edit`.
+- Changes to the repo-tier file format or `RouteDecisions` semantics for the
+  non-`--all` path.
+
+## Test plan
+
+- `ComputeReviewableRulesAll` unit tests:
+  - empty `tool-uses/` dir → empty result
+  - two logs with overlapping rules → deduped
+  - rule already in global tier → excluded
+  - rule only in a repo tier → **not** excluded (Q2 confirmation)
+  - `Read($HOME/.claude/*)` auto-exclusion still applies
+- Parse-error path: `repo` action in `--all` mode → editor reopens with error
+- Cmd-level: `--all` + positional arg → error before editor opens
+- `--all --dry-run` prints expected global promotions and no writes
+- End-to-end: populate two fake logs, run `--all`, accept all as `global`,
+  assert `global.json` contains the union

--- a/internal/claude/trust_test.go
+++ b/internal/claude/trust_test.go
@@ -42,7 +42,7 @@ func TestTrustWorkspacePreservesExisting(t *testing.T) {
 		"projects": map[string]any{
 			"/other/path": map[string]any{
 				"hasTrustDialogAccepted": true,
-				"customKey":             "value",
+				"customKey":              "value",
 			},
 		},
 	}

--- a/internal/clean/clean.go
+++ b/internal/clean/clean.go
@@ -10,9 +10,9 @@ import (
 	"github.com/charmbracelet/lipgloss"
 	"github.com/charmbracelet/log"
 
+	tap "github.com/amarbel-llc/bob/packages/tap-dancer/go"
 	"github.com/amarbel-llc/spinclass/internal/git"
 	"github.com/amarbel-llc/spinclass/internal/session"
-	tap "github.com/amarbel-llc/bob/packages/tap-dancer/go"
 	"github.com/amarbel-llc/spinclass/internal/worktree"
 )
 

--- a/internal/executor/session.go
+++ b/internal/executor/session.go
@@ -9,8 +9,8 @@ import (
 	"syscall"
 	"time"
 
-	"github.com/amarbel-llc/spinclass/internal/session"
 	tap "github.com/amarbel-llc/bob/packages/tap-dancer/go"
+	"github.com/amarbel-llc/spinclass/internal/session"
 )
 
 type SessionExecutor struct {

--- a/internal/hooks/hooks.go
+++ b/internal/hooks/hooks.go
@@ -291,4 +291,3 @@ func runPostToolUseLog(input hookInput) error {
 
 	return nil
 }
-

--- a/internal/merge/merge.go
+++ b/internal/merge/merge.go
@@ -11,11 +11,11 @@ import (
 	"github.com/charmbracelet/huh"
 	"github.com/charmbracelet/log"
 
+	tap "github.com/amarbel-llc/bob/packages/tap-dancer/go"
 	"github.com/amarbel-llc/spinclass/internal/executor"
 	"github.com/amarbel-llc/spinclass/internal/git"
 	"github.com/amarbel-llc/spinclass/internal/session"
 	"github.com/amarbel-llc/spinclass/internal/sweatfile"
-	tap "github.com/amarbel-llc/bob/packages/tap-dancer/go"
 	"github.com/amarbel-llc/spinclass/internal/worktree"
 )
 

--- a/internal/perms/cmd.go
+++ b/internal/perms/cmd.go
@@ -42,12 +42,20 @@ func newCheckCmd() *cobra.Command {
 func newReviewCmd() *cobra.Command {
 	var worktreeDir string
 	var dryRun bool
+	var all bool
 
 	cmd := &cobra.Command{
 		Use:   "review [worktree-path]",
 		Short: "Interactively review new permissions from a session",
 		Args:  cobra.MaximumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
+			if all {
+				if len(args) > 0 || worktreeDir != "" {
+					return fmt.Errorf("--all cannot be combined with [worktree-path] or --worktree-dir")
+				}
+				return RunReviewEditorAll(dryRun)
+			}
+
 			var worktreePath string
 
 			switch {
@@ -83,6 +91,7 @@ func newReviewCmd() *cobra.Command {
 
 	cmd.Flags().StringVar(&worktreeDir, "worktree-dir", "", "override worktree path")
 	cmd.Flags().BoolVar(&dryRun, "dry-run", false, "show what would change without writing")
+	cmd.Flags().BoolVar(&all, "all", false, "review across every session's tool-use log; only global promotion is allowed")
 
 	return cmd
 }
@@ -312,6 +321,115 @@ func RunReviewEditor(worktreePath, repoName string, dryRun bool) error {
 			return nil
 		}
 	}
+}
+
+// RunReviewEditorAll opens $EDITOR with reviewable rules merged across every
+// session's tool-use log. The 'repo' action is rejected because there is no
+// single repo context; rules can only be promoted to the global tier.
+func RunReviewEditorAll(dryRun bool) error {
+	tiersDir := TiersDir()
+	globalSettingsPath := GlobalClaudeSettingsPath()
+
+	rules, err := ComputeReviewableRulesAll(tiersDir, globalSettingsPath)
+	if err != nil {
+		return err
+	}
+
+	if len(rules) == 0 {
+		fmt.Println("no new permissions to review across any session")
+		return nil
+	}
+
+	content := FormatEditorContentAll(rules)
+
+	tmpFile, err := os.CreateTemp("", "spinclass-perms-review-all-*.txt")
+	if err != nil {
+		return err
+	}
+	defer os.Remove(tmpFile.Name())
+
+	if _, err := tmpFile.WriteString(content); err != nil {
+		tmpFile.Close()
+		return err
+	}
+	tmpFile.Close()
+
+	for {
+		if err := openEditor(tmpFile.Name()); err != nil {
+			return fmt.Errorf("editor failed: %w", err)
+		}
+
+		edited, err := os.ReadFile(tmpFile.Name())
+		if err != nil {
+			return err
+		}
+
+		decisions, err := ParseEditorContent(string(edited))
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "Parse error: %v\nRe-opening editor.\n", err)
+			continue
+		}
+
+		if invalid := firstRepoDecision(decisions); invalid != "" {
+			fmt.Fprintf(os.Stderr, "'repo' action is not valid in --all mode (rule: %s)\nRe-opening editor.\n", invalid)
+			continue
+		}
+
+		if len(decisions) == 0 {
+			fmt.Println("no decisions — aborting")
+			return nil
+		}
+
+		fmt.Println()
+		for _, d := range decisions {
+			friendly := FriendlyName(d.Rule)
+			if friendly != "" {
+				fmt.Printf("  %-8s %s  # %s\n", d.Action, d.Rule, friendly)
+			} else {
+				fmt.Printf("  %-8s %s\n", d.Action, d.Rule)
+			}
+		}
+		fmt.Println()
+
+		var choice string
+		prompt := huh.NewSelect[string]().
+			Title("Review complete").
+			Options(
+				huh.NewOption("Accept", "accept"),
+				huh.NewOption("Edit again", "edit"),
+				huh.NewOption("Abort", "abort"),
+			).
+			Value(&choice)
+
+		if err := prompt.Run(); err != nil {
+			return err
+		}
+
+		switch choice {
+		case "accept":
+			if dryRun {
+				DryRunDecisions(os.Stdout, tiersDir, "", decisions)
+				return nil
+			}
+			return RouteDecisions(tiersDir, "", decisions)
+		case "edit":
+			continue
+		case "abort":
+			fmt.Println("aborted")
+			return nil
+		}
+	}
+}
+
+// firstRepoDecision returns the first rule whose action is ReviewPromoteRepo,
+// or "" if none. Used to reject 'repo' decisions in --all mode.
+func firstRepoDecision(decisions []ReviewDecision) string {
+	for _, d := range decisions {
+		if d.Action == ReviewPromoteRepo {
+			return d.Rule
+		}
+	}
+	return ""
 }
 
 func openEditor(path string) error {

--- a/internal/perms/editor.go
+++ b/internal/perms/editor.go
@@ -72,16 +72,39 @@ func FormatEditorContent(rules []string, repoName string) string {
 	fmt.Fprintf(&b, "# Repo: %s\n", repoName)
 	b.WriteString("\n")
 
+	writeRuleLines(&b, sorted)
+	return b.String()
+}
+
+// FormatEditorContentAll generates the editor buffer content for `sc perms
+// review --all`. The header notes that 'repo' is not a valid action because
+// there is no single repo context.
+func FormatEditorContentAll(rules []string) string {
+	sorted := make([]string, len(rules))
+	copy(sorted, rules)
+	sort.Strings(sorted)
+
+	var b strings.Builder
+
+	b.WriteString("# spinclass perms review (all sessions) — change the action word for each permission\n")
+	b.WriteString("# Actions: global | keep | discard (unique prefixes OK: g/k/d)\n")
+	b.WriteString("# 'repo' is NOT valid in --all mode (no single repo context).\n")
+	b.WriteString("# Lines starting with # are ignored. Empty lines are ignored.\n")
+	b.WriteString("\n")
+
+	writeRuleLines(&b, sorted)
+	return b.String()
+}
+
+func writeRuleLines(b *strings.Builder, sorted []string) {
 	for _, rule := range sorted {
 		friendly := FriendlyName(rule)
 		if friendly != "" {
-			fmt.Fprintf(&b, "discard %s  # %s\n", rule, friendly)
+			fmt.Fprintf(b, "discard %s  # %s\n", rule, friendly)
 		} else {
-			fmt.Fprintf(&b, "discard %s\n", rule)
+			fmt.Fprintf(b, "discard %s\n", rule)
 		}
 	}
-
-	return b.String()
 }
 
 // ParseEditorContent parses the editor buffer back into ReviewDecisions.

--- a/internal/perms/settings.go
+++ b/internal/perms/settings.go
@@ -8,6 +8,7 @@ import (
 	"io/fs"
 	"os"
 	"path/filepath"
+	"sort"
 	"strings"
 )
 
@@ -249,4 +250,114 @@ func ToolUseLogPath(repoName, branch string) string {
 	}
 	filename := strings.ReplaceAll(repoName+"/"+branch, "/", "--") + ".jsonl"
 	return filepath.Join(base, "spinclass", "tool-uses", filename)
+}
+
+// ToolUseLogDir returns the XDG directory containing per-session tool-use
+// logs.
+func ToolUseLogDir() string {
+	base := os.Getenv("XDG_LOG_HOME")
+	if base == "" {
+		home, _ := os.UserHomeDir()
+		if home == "" {
+			return ""
+		}
+		base = filepath.Join(home, ".local", "log")
+	}
+	return filepath.Join(base, "spinclass", "tool-uses")
+}
+
+// DiscoverToolUseLogs walks the tool-use log directory and returns the absolute
+// path of every *.jsonl file found, sorted for stable iteration. Returns an
+// empty slice if the directory does not exist.
+func DiscoverToolUseLogs() ([]string, error) {
+	dir := ToolUseLogDir()
+	if dir == "" {
+		return nil, nil
+	}
+
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		if errors.Is(err, fs.ErrNotExist) {
+			return nil, nil
+		}
+		return nil, err
+	}
+
+	var paths []string
+	for _, entry := range entries {
+		if entry.IsDir() {
+			continue
+		}
+		if !strings.HasSuffix(entry.Name(), ".jsonl") {
+			continue
+		}
+		paths = append(paths, filepath.Join(dir, entry.Name()))
+	}
+
+	sort.Strings(paths)
+	return paths, nil
+}
+
+// ComputeReviewableRulesAll returns rules derived from every session's
+// tool-use log that are not already covered by global Claude settings or the
+// global curated tier file. Used by `sc perms review --all`. Per-repo tier
+// rules are intentionally NOT excluded — a rule already in repos/A.json may
+// still be a legitimate candidate for global promotion when it appears in
+// repo B's log.
+func ComputeReviewableRulesAll(
+	tiersDir, globalSettingsPath string,
+) ([]string, error) {
+	logs, err := DiscoverToolUseLogs()
+	if err != nil {
+		return nil, err
+	}
+
+	seen := make(map[string]bool)
+	var allRules []string
+	for _, logPath := range logs {
+		rules, err := LoadRulesFromLog(logPath)
+		if err != nil {
+			return nil, err
+		}
+		for _, r := range rules {
+			if !seen[r] {
+				seen[r] = true
+				allRules = append(allRules, r)
+			}
+		}
+	}
+
+	globalRules, err := LoadClaudeSettings(globalSettingsPath)
+	if err != nil {
+		return nil, err
+	}
+
+	globalTier, err := LoadTierFile(filepath.Join(tiersDir, "global.json"))
+	if err != nil {
+		return nil, err
+	}
+
+	var excludeRules []string
+	excludeRules = append(excludeRules, globalRules...)
+	excludeRules = append(excludeRules, globalTier.Allow...)
+
+	home, _ := os.UserHomeDir()
+	if home != "" {
+		excludeRules = append(excludeRules, fmt.Sprintf("Read(%s/.claude/*)", home))
+	}
+
+	var result []string
+	for _, r := range allRules {
+		ruleTool, ruleArg := parseRule(r)
+		toolInput := rebuildToolInput(ruleTool, ruleArg)
+		if !MatchesAnyRule(excludeRules, ruleTool, toolInput) {
+			result = append(result, r)
+		}
+	}
+
+	if result == nil {
+		result = []string{}
+	}
+
+	return result, nil
 }

--- a/internal/perms/settings_test.go
+++ b/internal/perms/settings_test.go
@@ -213,6 +213,141 @@ func TestLoadRulesFromLogMissing(t *testing.T) {
 	}
 }
 
+func TestDiscoverToolUseLogs(t *testing.T) {
+	tmpDir := t.TempDir()
+	t.Setenv("XDG_LOG_HOME", tmpDir)
+
+	// Empty / missing directory
+	logs, err := DiscoverToolUseLogs()
+	if err != nil {
+		t.Fatalf("expected no error for missing dir, got %v", err)
+	}
+	if len(logs) != 0 {
+		t.Errorf("expected no logs for missing dir, got %v", logs)
+	}
+
+	// Populate dir with mixed file types
+	logDir := filepath.Join(tmpDir, "spinclass", "tool-uses")
+	os.MkdirAll(logDir, 0o755)
+	os.WriteFile(filepath.Join(logDir, "repoA--branch1.jsonl"), []byte("{}\n"), 0o644)
+	os.WriteFile(filepath.Join(logDir, "repoB--branch2.jsonl"), []byte("{}\n"), 0o644)
+	os.WriteFile(filepath.Join(logDir, "ignored.txt"), []byte("noise\n"), 0o644)
+	os.MkdirAll(filepath.Join(logDir, "subdir"), 0o755)
+
+	logs, err = DiscoverToolUseLogs()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(logs) != 2 {
+		t.Fatalf("expected 2 logs, got %d: %v", len(logs), logs)
+	}
+	// Sorted order
+	if !strings.HasSuffix(logs[0], "repoA--branch1.jsonl") {
+		t.Errorf("expected repoA log first, got %q", logs[0])
+	}
+	if !strings.HasSuffix(logs[1], "repoB--branch2.jsonl") {
+		t.Errorf("expected repoB log second, got %q", logs[1])
+	}
+}
+
+func TestComputeReviewableRulesAll(t *testing.T) {
+	tmpDir := t.TempDir()
+	t.Setenv("HOME", "/Users/me")
+	t.Setenv("XDG_LOG_HOME", tmpDir)
+
+	logDir := filepath.Join(tmpDir, "spinclass", "tool-uses")
+	os.MkdirAll(logDir, 0o755)
+
+	// Two sessions with overlapping rules
+	os.WriteFile(filepath.Join(logDir, "repoA--main.jsonl"), []byte(strings.Join([]string{
+		`{"tool_name":"Bash","tool_input":{"command":"go test ./..."}}`,
+		`{"tool_name":"Bash","tool_input":{"command":"nix build"}}`,
+		`{"tool_name":"Edit","tool_input":{"file_path":"/Users/me/repos/A/main.go"}}`,
+		`{"tool_name":"Glob","tool_input":{}}`,
+		`{"tool_name":"Read","tool_input":{"file_path":"/Users/me/.claude/CLAUDE.md"}}`,
+		`{"tool_name":"mcp__plugin_grit_grit__add","tool_input":{}}`,
+	}, "\n")+"\n"), 0o644)
+	os.WriteFile(filepath.Join(logDir, "repoB--feat.jsonl"), []byte(strings.Join([]string{
+		`{"tool_name":"Bash","tool_input":{"command":"go test ./..."}}`, // dup
+		`{"tool_name":"Bash","tool_input":{"command":"cargo test"}}`,
+		`{"tool_name":"WebSearch","tool_input":{}}`,
+	}, "\n")+"\n"), 0o644)
+
+	// Global Claude settings cover Glob and WebSearch
+	globalSettingsPath := filepath.Join(tmpDir, "global-settings.json")
+	if err := SaveClaudeSettings(globalSettingsPath, []string{
+		"Glob",
+		"WebSearch",
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	// Tier files: global tier excludes Edit; per-repo tier includes
+	// Bash(go test ./...) — should NOT be excluded in --all mode.
+	tiersDir := filepath.Join(tmpDir, "tiers")
+	os.MkdirAll(filepath.Join(tiersDir, "repos"), 0o755)
+	if err := SaveTierFile(filepath.Join(tiersDir, "global.json"), Tier{Allow: []string{"Edit"}}); err != nil {
+		t.Fatal(err)
+	}
+	if err := SaveTierFile(filepath.Join(tiersDir, "repos", "repoA.json"), Tier{Allow: []string{"Bash(go test ./...)"}}); err != nil {
+		t.Fatal(err)
+	}
+
+	got, err := ComputeReviewableRulesAll(tiersDir, globalSettingsPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Should contain (deduped across logs):
+	// - Bash(go test ./...) — repo tier rule does NOT exclude it in --all
+	// - Bash(nix build)
+	// - Bash(cargo test)
+	// - mcp__plugin_grit_grit__add
+	// Should NOT contain:
+	// - Edit(/Users/me/repos/A/main.go)  — bare Edit in global tier matches
+	// - Glob, WebSearch                  — in global Claude settings
+	// - Read(/Users/me/.claude/CLAUDE.md) — auto-injected ~/.claude exclusion
+	wantSet := map[string]bool{
+		"Bash(go test ./...)":        true,
+		"Bash(nix build)":            true,
+		"Bash(cargo test)":           true,
+		"mcp__plugin_grit_grit__add": true,
+	}
+
+	gotSet := map[string]bool{}
+	for _, r := range got {
+		gotSet[r] = true
+	}
+
+	for want := range wantSet {
+		if !gotSet[want] {
+			t.Errorf("expected %q in reviewable rules, got %v", want, got)
+		}
+	}
+	for _, r := range got {
+		if !wantSet[r] {
+			t.Errorf("unexpected rule %q in reviewable rules", r)
+		}
+	}
+}
+
+func TestComputeReviewableRulesAllEmpty(t *testing.T) {
+	tmpDir := t.TempDir()
+	t.Setenv("HOME", "/Users/me")
+	t.Setenv("XDG_LOG_HOME", tmpDir)
+
+	got, err := ComputeReviewableRulesAll(
+		filepath.Join(tmpDir, "tiers"),
+		filepath.Join(tmpDir, "global-settings.json"),
+	)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(got) != 0 {
+		t.Errorf("expected no rules for empty log dir, got %v", got)
+	}
+}
+
 func TestComputeReviewableRules(t *testing.T) {
 	tmpDir := t.TempDir()
 
@@ -267,9 +402,9 @@ func TestComputeReviewableRules(t *testing.T) {
 	// Should NOT contain: Edit (bare, in tier), Glob (global), WebSearch (global),
 	// Read/Edit/Write worktree paths, Read(~/.claude/*)
 	wantSet := map[string]bool{
-		"Bash(go test ./...)":          true,
-		"Bash(nix build)":              true,
-		"mcp__plugin_grit_grit__add":   true,
+		"Bash(go test ./...)":        true,
+		"Bash(nix build)":            true,
+		"mcp__plugin_grit_grit__add": true,
 	}
 
 	gotSet := map[string]bool{}

--- a/internal/pull/pull.go
+++ b/internal/pull/pull.go
@@ -5,8 +5,8 @@ import (
 	"os"
 	"path/filepath"
 
-	"github.com/amarbel-llc/spinclass/internal/git"
 	tap "github.com/amarbel-llc/bob/packages/tap-dancer/go"
+	"github.com/amarbel-llc/spinclass/internal/git"
 	"github.com/amarbel-llc/spinclass/internal/worktree"
 )
 

--- a/internal/shop/prompt.go
+++ b/internal/shop/prompt.go
@@ -15,7 +15,7 @@ const (
 func promptDirtyAction(branch string) (dirtyAction, error) {
 	var action dirtyAction
 	err := huh.NewSelect[dirtyAction]().
-		Title("Worktree " + branch + " has uncommitted changes").
+		Title("Worktree "+branch+" has uncommitted changes").
 		Options(
 			huh.NewOption(string(actionDiscard), actionDiscard),
 			huh.NewOption(string(actionReattach), actionReattach),

--- a/internal/shop/shop_test.go
+++ b/internal/shop/shop_test.go
@@ -8,9 +8,9 @@ import (
 	"strings"
 	"testing"
 
+	tap "github.com/amarbel-llc/bob/packages/tap-dancer/go"
 	"github.com/amarbel-llc/spinclass/internal/git"
 	"github.com/amarbel-llc/spinclass/internal/worktree"
-	tap "github.com/amarbel-llc/bob/packages/tap-dancer/go"
 )
 
 func TestStatusDescription(t *testing.T) {
@@ -412,7 +412,6 @@ func TestForkAutoName(t *testing.T) {
 
 	var buf bytes.Buffer
 	err := Fork(&buf, rp, "", "tap")
-
 	if err != nil {
 		t.Fatalf("Fork() error: %v", err)
 	}

--- a/internal/status/status.go
+++ b/internal/status/status.go
@@ -9,9 +9,9 @@ import (
 
 	"github.com/charmbracelet/lipgloss"
 
+	tap "github.com/amarbel-llc/bob/packages/tap-dancer/go"
 	"github.com/amarbel-llc/spinclass/internal/git"
 	"github.com/amarbel-llc/spinclass/internal/session"
-	tap "github.com/amarbel-llc/bob/packages/tap-dancer/go"
 	"github.com/amarbel-llc/spinclass/internal/worktree"
 )
 


### PR DESCRIPTION
Plan doc exploring a `--all` flag for `sc perms review` that merges every tool-use log across repos and sessions into a single review pass.

## Summary

- Drops the `repo` action (no single repo context when reviewing across repos) — only `global | keep | discard` are offered.
- Mutually exclusive with the `[worktree-path]` arg and `--worktree-dir`.
- New helpers: `DiscoverToolUseLogs()`, `ComputeReviewableRulesAll()`, `RunReviewEditorAll()`.
- `RouteDecisions` / `DryRunDecisions` signatures unchanged; `repo=""` in `--all`.

## Open questions (please comment inline on the raw markdown)

1. Worktree-noise strategy — accept noise (a), per-log exclusions via session state (b), or heuristic glob (c)?
2. Repo-tier exclusions — confirm that `--all` excludes only the global tier, not per-repo tiers.
3. Origin comments — include `# seen in: repoA, repoB` per rule?
4. Flag name — `--all` vs `--all-sessions` vs `--merge-all`.
5. Scope creep — `--since <duration>` filter: deferred?

No implementation in this PR — doc only. Merging this unblocks the follow-up implementation PR.

## Test plan

- [ ] Review design doc
- [ ] Resolve open questions
- [ ] (Follow-up PR) Implement + unit tests listed in the doc