### PR TITLE
Split start into start, start-gh_pr, start-gh_issue

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -98,7 +98,9 @@ worktree paths. Applies `claude-allow` rules from sweatfile to
 
   Command                          Description
   -------------------------------- ---------------------------------------------------------
-  `sc start "<desc>"`              Create and start a new worktree session (--pr N or --pr URL)
+  `sc start "<desc>"`              Create and start a new worktree session
+  `sc start-gh_pr <N|URL>`         Start a session from a GitHub pull request
+  `sc start-gh_issue <N>`          Start a session with GitHub issue context
   `sc resume [id]`                 Resume an existing session (auto-detects from cwd)
   `sc update-description "<desc>"` Update session description (--id or auto-detect)
   `sc list`                        List all tracked sessions from state directory
@@ -109,9 +111,11 @@ worktree paths. Applies `claude-allow` rules from sweatfile to
   `sc validate`                    Validate sweatfile hierarchy
   `sc perms list|review|edit`      Inspect or edit permission tier rules
 
-`start` and `update-description` take their description as a single
-positional argument. Multi-word descriptions must be quoted, e.g.
-`sc start "fix login bug"`. Note that the underlying registered subcommands
+`start`, `start-gh_pr`, `start-gh_issue`, and `update-description` take
+their primary argument as a single positional value. Multi-word descriptions
+must be quoted, e.g. `sc start "fix login bug"`. `start-gh_pr` and
+`start-gh_issue` offer tab completion for open PRs and issues respectively.
+Note that the underlying registered subcommands
 use hyphenated names (`perms-list`, `perms-review`, `perms-edit`), but the
 space-separated form (`sc perms list`) is also accepted.
 

--- a/cmd/spinclass/commands_session.go
+++ b/cmd/spinclass/commands_session.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"os"
+	"os/exec"
 	"path/filepath"
 
 	"github.com/charmbracelet/huh"
@@ -34,10 +35,38 @@ func registerSessionCommands(app *command.App) {
 			{Name: "description", Type: command.String, Description: "Freeform session description (quote multi-word strings)"},
 			{Name: "merge-on-close", Type: command.Bool, Description: "Auto-merge worktree into default branch on session close"},
 			{Name: "no-attach", Type: command.Bool, Description: "Create worktree but skip attaching"},
-			{Name: "pr", Type: command.String, Description: "Start session from a PR (number or GitHub URL)"},
-			{Name: "issue", Type: command.String, Description: "Start session with GitHub issue context (number)"},
 		},
 		RunCLI: runStart,
+	})
+
+	app.AddCommand(&command.Command{
+		Name: "start-gh_pr",
+		Description: command.Description{
+			Short: "Start a session from a GitHub pull request",
+			Long:  "Create a new worktree session from an existing GitHub PR. Fetches the PR branch and sets up session context with PR metadata.",
+		},
+		Params: []command.Param{
+			{Name: "pr", Type: command.String, Description: "PR number or GitHub URL", Required: true, Completer: completeGHPRs},
+			{Name: "description", Type: command.String, Description: "Override the PR title as session description"},
+			{Name: "merge-on-close", Type: command.Bool, Description: "Auto-merge worktree into default branch on session close"},
+			{Name: "no-attach", Type: command.Bool, Description: "Create worktree but skip attaching"},
+		},
+		RunCLI: runStartGHPR,
+	})
+
+	app.AddCommand(&command.Command{
+		Name: "start-gh_issue",
+		Description: command.Description{
+			Short: "Start a session with a GitHub issue",
+			Long:  "Create a new worktree session with GitHub issue context. The issue metadata is included in the session's system prompt.",
+		},
+		Params: []command.Param{
+			{Name: "issue", Type: command.String, Description: "Issue number", Required: true, Completer: completeGHIssues},
+			{Name: "description", Type: command.String, Description: "Freeform session description (quote multi-word strings)"},
+			{Name: "merge-on-close", Type: command.Bool, Description: "Auto-merge worktree into default branch on session close"},
+			{Name: "no-attach", Type: command.Bool, Description: "Create worktree but skip attaching"},
+		},
+		RunCLI: runStartGHIssue,
 	})
 
 	app.AddCommand(&command.Command{
@@ -119,85 +148,61 @@ func registerSessionCommands(app *command.App) {
 	})
 }
 
-func runStart(_ context.Context, args json.RawMessage) error {
-	var p struct {
-		globalArgs
-		Description  string `json:"description"`
-		MergeOnClose bool   `json:"merge-on-close"`
-		NoAttach     bool   `json:"no-attach"`
-		PR           string `json:"pr"`
-		Issue        string `json:"issue"`
-	}
-	_ = json.Unmarshal(args, &p)
-
-	if p.PR != "" && p.Issue != "" {
-		return fmt.Errorf("--pr and --issue are mutually exclusive")
-	}
-
-	cwd, err := os.Getwd()
+func completeGHPRs() map[string]string {
+	out, err := exec.Command(
+		"gh", "pr", "list", "--json", "number,title", "--limit", "20",
+	).Output()
 	if err != nil {
-		return err
+		return nil
 	}
 
-	repoPath, err := worktree.DetectRepo(cwd)
+	var prs []struct {
+		Number int    `json:"number"`
+		Title  string `json:"title"`
+	}
+	if json.Unmarshal(out, &prs) != nil {
+		return nil
+	}
+
+	result := make(map[string]string, len(prs))
+	for _, p := range prs {
+		result[fmt.Sprintf("%d", p.Number)] = p.Title
+	}
+	return result
+}
+
+func completeGHIssues() map[string]string {
+	out, err := exec.Command(
+		"gh", "issue", "list", "--json", "number,title", "--limit", "20",
+	).Output()
 	if err != nil {
-		return err
+		return nil
 	}
 
-	var resolvedPath worktree.ResolvedPath
-
-	if p.PR != "" {
-		prInfo, err := pr.Resolve(p.PR, repoPath)
-		if err != nil {
-			return err
-		}
-
-		branch := prInfo.HeadRefName
-
-		if !git.BranchExists(repoPath, branch) {
-			if _, err := git.Run(repoPath, "fetch", "origin", branch); err != nil {
-				return fmt.Errorf("fetching PR branch %q: %w", branch, err)
-			}
-		}
-
-		absPath := filepath.Join(repoPath, worktree.WorktreesDir, branch)
-		repoDirname := filepath.Base(repoPath)
-
-		description := fmt.Sprintf("%s (#%d)", prInfo.Title, prInfo.Number)
-		if p.Description != "" {
-			description = p.Description
-		}
-
-		resolvedPath = worktree.ResolvedPath{
-			AbsPath:        absPath,
-			RepoPath:       repoPath,
-			SessionKey:     repoDirname + "/" + branch,
-			Branch:         branch,
-			Description:    description,
-			ExistingBranch: branch,
-		}
-
-		if prData, prErr := prompt.FetchPR(p.PR, repoPath); prErr == nil {
-			resolvedPath.PR = &prData
-		}
-	} else {
-		var descArgs []string
-		if p.Description != "" {
-			descArgs = []string{p.Description}
-		}
-		resolvedPath, err = worktree.ResolvePath(repoPath, descArgs)
-		if err != nil {
-			return err
-		}
+	var issues []struct {
+		Number int    `json:"number"`
+		Title  string `json:"title"`
+	}
+	if json.Unmarshal(out, &issues) != nil {
+		return nil
 	}
 
-	if p.Issue != "" {
-		issueData, err := prompt.FetchIssue(p.Issue, repoPath)
-		if err != nil {
-			return fmt.Errorf("fetching issue: %w", err)
-		}
-		resolvedPath.Issue = &issueData
+	result := make(map[string]string, len(issues))
+	for _, i := range issues {
+		result[fmt.Sprintf("%d", i.Number)] = i.Title
 	}
+	return result
+}
+
+type startArgs struct {
+	globalArgs
+	Description  string `json:"description"`
+	MergeOnClose bool   `json:"merge-on-close"`
+	NoAttach     bool   `json:"no-attach"`
+}
+
+func attachSession(resolvedPath worktree.ResolvedPath, args startArgs) error {
+	repoPath := resolvedPath.RepoPath
 
 	hierarchy, err := sweatfile.LoadWorktreeHierarchy(
 		os.Getenv("HOME"), repoPath, resolvedPath.AbsPath,
@@ -218,11 +223,128 @@ func runStart(_ context.Context, args json.RawMessage) error {
 		os.Stdout,
 		exec,
 		resolvedPath,
-		p.FormatOrDefault(),
-		p.MergeOnClose,
-		p.NoAttach,
-		p.Verbose,
+		args.FormatOrDefault(),
+		args.MergeOnClose,
+		args.NoAttach,
+		args.Verbose,
 	)
+}
+
+func runStart(_ context.Context, args json.RawMessage) error {
+	var p startArgs
+	_ = json.Unmarshal(args, &p)
+
+	cwd, err := os.Getwd()
+	if err != nil {
+		return err
+	}
+
+	repoPath, err := worktree.DetectRepo(cwd)
+	if err != nil {
+		return err
+	}
+
+	var descArgs []string
+	if p.Description != "" {
+		descArgs = []string{p.Description}
+	}
+
+	resolvedPath, err := worktree.ResolvePath(repoPath, descArgs)
+	if err != nil {
+		return err
+	}
+
+	return attachSession(resolvedPath, p)
+}
+
+func runStartGHPR(_ context.Context, args json.RawMessage) error {
+	var p struct {
+		startArgs
+		PR string `json:"pr"`
+	}
+	_ = json.Unmarshal(args, &p)
+
+	cwd, err := os.Getwd()
+	if err != nil {
+		return err
+	}
+
+	repoPath, err := worktree.DetectRepo(cwd)
+	if err != nil {
+		return err
+	}
+
+	prInfo, err := pr.Resolve(p.PR, repoPath)
+	if err != nil {
+		return err
+	}
+
+	branch := prInfo.HeadRefName
+
+	if !git.BranchExists(repoPath, branch) {
+		if _, err := git.Run(repoPath, "fetch", "origin", branch); err != nil {
+			return fmt.Errorf("fetching PR branch %q: %w", branch, err)
+		}
+	}
+
+	absPath := filepath.Join(repoPath, worktree.WorktreesDir, branch)
+	repoDirname := filepath.Base(repoPath)
+
+	description := fmt.Sprintf("%s (#%d)", prInfo.Title, prInfo.Number)
+	if p.Description != "" {
+		description = p.Description
+	}
+
+	resolvedPath := worktree.ResolvedPath{
+		AbsPath:        absPath,
+		RepoPath:       repoPath,
+		SessionKey:     repoDirname + "/" + branch,
+		Branch:         branch,
+		Description:    description,
+		ExistingBranch: branch,
+	}
+
+	if prData, prErr := prompt.FetchPR(p.PR, repoPath); prErr == nil {
+		resolvedPath.PR = &prData
+	}
+
+	return attachSession(resolvedPath, p.startArgs)
+}
+
+func runStartGHIssue(_ context.Context, args json.RawMessage) error {
+	var p struct {
+		startArgs
+		Issue string `json:"issue"`
+	}
+	_ = json.Unmarshal(args, &p)
+
+	cwd, err := os.Getwd()
+	if err != nil {
+		return err
+	}
+
+	repoPath, err := worktree.DetectRepo(cwd)
+	if err != nil {
+		return err
+	}
+
+	var descArgs []string
+	if p.Description != "" {
+		descArgs = []string{p.Description}
+	}
+
+	resolvedPath, err := worktree.ResolvePath(repoPath, descArgs)
+	if err != nil {
+		return err
+	}
+
+	issueData, err := prompt.FetchIssue(p.Issue, repoPath)
+	if err != nil {
+		return fmt.Errorf("fetching issue: %w", err)
+	}
+	resolvedPath.Issue = &issueData
+
+	return attachSession(resolvedPath, p.startArgs)
 }
 
 func runResume(_ context.Context, args json.RawMessage) error {


### PR DESCRIPTION
## Summary

- Split `start` command into three: plain `start`, `start-gh_pr` (PR number or URL), and `start-gh_issue` (issue number)
- Fixes positional description parsing — `sc start "my description"` no longer fails with "pr and issue are mutually exclusive"
- `start-gh_pr` and `start-gh_issue` include tab completion for open PRs/issues via `gh` CLI
- Shared session-setup logic extracted into `startArgs` struct and `attachSession()` helper

## Test plan

- [x] `go test ./...` — all tests pass
- [x] `go vet ./...` — clean
- [x] `nix build` — succeeds, generated completions include new commands with dynamic completers
- [ ] Manual: `sc start "plain desc"` creates a session with description
- [ ] Manual: `sc start-gh_pr <number>` creates a session from a PR
- [ ] Manual: `sc start-gh_issue <number>` creates a session with issue context

🤖 Generated with [Claude Code](https://claude.com/claude-code)