### PR TITLE
fix: update go-mcp v0.0.6 → v0.0.7 for positional arg completions

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.26
 
 require (
 	github.com/amarbel-llc/bob/packages/tap-dancer/go v0.1.0
-	github.com/amarbel-llc/purse-first/libs/go-mcp v0.0.6
+	github.com/amarbel-llc/purse-first/libs/go-mcp v0.0.7
 	github.com/amarbel-llc/purse-first/libs/go-mcp/command/huh v0.0.4
 	github.com/amarbel-llc/tommy v0.0.0-20260326195616-1e3aa70b25d0
 	github.com/charmbracelet/huh v1.0.0

--- a/go.sum
+++ b/go.sum
@@ -2,8 +2,8 @@ github.com/MakeNowJust/heredoc v1.0.0 h1:cXCdzVdstXyiTqTvfqk9SDHpKNjxuom+DOlyEeQ
 github.com/MakeNowJust/heredoc v1.0.0/go.mod h1:mG5amYoWBHf8vpLOuehzbGGw0EHxpZZ6lCpQ4fNJ8LE=
 github.com/amarbel-llc/bob/packages/tap-dancer/go v0.1.0 h1:+8QbL84Q9IVcKUPm0DJ4emTwXndujB86ATqyNCem+KQ=
 github.com/amarbel-llc/bob/packages/tap-dancer/go v0.1.0/go.mod h1:f/eBRNyz3TVY+bB5bnNmYioJEgNrmwbvscFq29VFyXc=
-github.com/amarbel-llc/purse-first/libs/go-mcp v0.0.6 h1:fznZS85yRKOmuF5ML0A3N/TTFBIajTP+Y7ZIHFZJqeA=
-github.com/amarbel-llc/purse-first/libs/go-mcp v0.0.6/go.mod h1:4QNwpEtQWg+aF++9BpxQq93cnj6puQfsARZ0Z4fHIHk=
+github.com/amarbel-llc/purse-first/libs/go-mcp v0.0.7 h1:jUmtBk7zbDG1L5APsvRr5ccB7hg3LwhfM+UwZLRZeAM=
+github.com/amarbel-llc/purse-first/libs/go-mcp v0.0.7/go.mod h1:4QNwpEtQWg+aF++9BpxQq93cnj6puQfsARZ0Z4fHIHk=
 github.com/amarbel-llc/purse-first/libs/go-mcp/command/huh v0.0.4 h1:3rKd2loQXbUwxihvfHn0twqAbUf/qoo+6rhU7pNE4Lc=
 github.com/amarbel-llc/purse-first/libs/go-mcp/command/huh v0.0.4/go.mod h1:TLptCeakiRrMP/nm5B3KA98/PCldo9KZdauzRNzC5Yc=
 github.com/amarbel-llc/tommy v0.0.0-20260326195616-1e3aa70b25d0 h1:8LPijZ6RcsaJTqU2jmB9MHcJxaO6bLd5QymjHsvUieQ=

--- a/gomod2nix.toml
+++ b/gomod2nix.toml
@@ -6,8 +6,8 @@ schema = 3
     hash = 'sha256-pC95VLeYUZwmcosmo2mtzh1Ggk7N9rlUtXPmf7eGDpE='
 
   [mod.'github.com/amarbel-llc/purse-first/libs/go-mcp']
-    version = 'v0.0.6'
-    hash = 'sha256-LGDYDUgy3doJVyrk3IcmS3/+8cukuR6K3Bkyp9lnHS4='
+    version = 'v0.0.7'
+    hash = 'sha256-ywtUFoGNG0esxMG1EIFd4Do70AS7fBZcuB9UACbYrLc='
 
   [mod.'github.com/amarbel-llc/purse-first/libs/go-mcp/command/huh']
     version = 'v0.0.4'


### PR DESCRIPTION
## Summary
- Bumps go-mcp from v0.0.6 to v0.0.7 to fix positional argument completions
- Shell completions now trigger for positional args (e.g. `start-gh_pr <TAB>`), not just `--flag` form
- Fixes amarbel-llc/purse-first#20

## Test plan
- [ ] Verify `nix build` succeeds in CI
- [ ] Confirm `sc start-gh_pr <TAB>` triggers PR completion

🤖 Generated with [Claude Code](https://claude.com/claude-code)