### PR TITLE
feat(start-commands): config-driven start-* commands via sweatfile

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -100,7 +100,8 @@ worktree paths. Applies `claude-allow` rules from sweatfile to
   -------------------------------- ---------------------------------------------------------
   `sc start "<desc>"`              Create and start a new worktree session
   `sc start-gh_pr <N|URL>`         Start a session from a GitHub pull request
-  `sc start-gh_issue <N>`          Start a session with GitHub issue context
+  `sc start-gh_issue <N>`          Start a session with GitHub issue context (config-driven, see below)
+  `sc start-<custom> <arg>`        User-defined start commands declared in sweatfile
   `sc resume [id]`                 Resume an existing session (auto-detects from cwd)
   `sc update-description "<desc>"` Update session description (--id or auto-detect)
   `sc list`                        List all tracked sessions from state directory
@@ -118,6 +119,41 @@ must be quoted, e.g. `sc start "fix login bug"`. `start-gh_pr` and
 Note that the underlying registered subcommands
 use hyphenated names (`perms-list`, `perms-review`, `perms-edit`), but the
 space-separated form (`sc perms list`) is also accepted.
+
+## Custom start commands
+
+`sc start-<name>` subcommands can be declared in a sweatfile via the
+`[[start-commands]]` array of tables. At CLI startup spinclass loads the
+sweatfile hierarchy for the current directory and dynamically registers one
+command per entry. Each command validates its single positional argument,
+offers tab completion, and injects a markdown fragment into the session's
+`.spinclass/system_prompt_append.d/3-start-<name>.md` which is picked up
+automatically by the `--append-system-prompt` flow.
+
+```toml
+[[start-commands]]
+name         = "jira"               # registers `sc start-jira`
+description  = "Start session for a JIRA ticket"
+arg-name     = "ticket"             # positional parameter name
+arg-help     = "JIRA ticket ID"
+arg-regex    = "^[A-Z]+-[0-9]+$"    # optional RE2 validator
+completion   = ["sh", "-c", "jira list --format '{{.Key}}\t{{.Summary}}'"]
+prompt       = ["jira", "show", "{arg}", "--markdown"]
+```
+
+- `completion` is exec'd at tab-completion time. Stdout is parsed as
+  `value\tdescription` lines into the completion map. Failures are silent.
+- `prompt` is exec'd when the command runs, with `{arg}` literally replaced
+  by the positional value in every argv element. Stdout is written verbatim
+  to `3-start-<name>.md`. The command is exec'd directly (no shell); wrap
+  in `sh -c` for shell features.
+- Entries merge across the sweatfile hierarchy (`global → parent → repo`)
+  and later definitions override earlier ones by `name`. The built-in
+  `gh_issue` entry ships via `sweatfile.GetDefault()` as a tracer bullet —
+  it is the same plugin mechanism users get, just baked in.
+- Built-in subcommands (e.g. `start` itself or `start-gh_pr`) always win
+  over a sweatfile entry with the same name; `sc validate` flags obviously
+  broken entries (missing `prompt`, bad name, non-compiling regex).
 
 ## Nix Build
 

--- a/cmd/spinclass/commands.go
+++ b/cmd/spinclass/commands.go
@@ -43,6 +43,10 @@ func buildApp() *command.App {
 	registerServeCommand(app)
 	registerMCPOnlyCommands(app)
 	registerGenerateArtifactsCommand(app)
+	// Plugin start-* commands must register AFTER the built-in session
+	// commands so the built-ins shadow any config entries of the same name
+	// via the `GetCommand` collision guard.
+	registerPluginStartCommands(app)
 
 	return app
 }

--- a/cmd/spinclass/commands_plugin.go
+++ b/cmd/spinclass/commands_plugin.go
@@ -1,0 +1,233 @@
+package main
+
+import (
+	"bufio"
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"os"
+	"os/exec"
+	"regexp"
+	"strings"
+
+	"github.com/amarbel-llc/purse-first/libs/go-mcp/command"
+	"github.com/amarbel-llc/spinclass/internal/prompt"
+	"github.com/amarbel-llc/spinclass/internal/sweatfile"
+	"github.com/amarbel-llc/spinclass/internal/worktree"
+)
+
+// registerPluginStartCommands loads the sweatfile hierarchy for the current
+// working directory and registers a `start-<name>` subcommand for each entry
+// in `[[start-commands]]`. On any load error it returns silently so `sc` stays
+// usable outside of a repo. Registration happens after the built-in session
+// commands and skips names that are already registered to preserve built-in
+// behaviour.
+func registerPluginStartCommands(app *command.App) {
+	merged, ok := loadMergedSweatfile()
+	if !ok {
+		return
+	}
+	for _, sc := range merged.StartCommands {
+		if sc.Name == "" || len(sc.Prompt) == 0 {
+			continue
+		}
+		cmdName := "start-" + sc.Name
+		if _, exists := app.GetCommand(cmdName); exists {
+			continue
+		}
+		app.AddCommand(buildPluginCommand(cmdName, sc))
+	}
+}
+
+// loadMergedSweatfile loads the sweatfile hierarchy from cwd with the
+// baseline (`GetDefault()`) merged on top, so built-in entries surface even
+// when the user has no repo/global sweatfile.
+func loadMergedSweatfile() (sweatfile.Sweatfile, bool) {
+	cwd, err := os.Getwd()
+	if err != nil {
+		return sweatfile.Sweatfile{}, false
+	}
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return sweatfile.Sweatfile{}, false
+	}
+	var merged sweatfile.Sweatfile
+	if repoPath, err := worktree.DetectRepo(cwd); err == nil {
+		hierarchy, err := sweatfile.LoadHierarchy(home, repoPath)
+		if err != nil {
+			return sweatfile.Sweatfile{}, false
+		}
+		merged = hierarchy.Merged
+	} else {
+		// Outside a repo: load only the global sweatfile (LoadHierarchy with
+		// home as the repoDir walks zero intermediate levels, so it just
+		// reads ~/.config/spinclass/sweatfile).
+		hierarchy, err := sweatfile.LoadHierarchy(home, home)
+		if err != nil {
+			return sweatfile.Sweatfile{}, false
+		}
+		merged = hierarchy.Merged
+	}
+	merged = merged.MergeWith(sweatfile.GetDefault())
+	return merged, true
+}
+
+func buildPluginCommand(cmdName string, sc sweatfile.StartCommand) *command.Command {
+	argName := sc.ArgName
+	if argName == "" {
+		argName = "arg"
+	}
+	shortDesc := sc.Description
+	if shortDesc == "" {
+		shortDesc = "Start a session via the " + sc.Name + " plugin"
+	}
+	return &command.Command{
+		Name: cmdName,
+		Description: command.Description{
+			Short: shortDesc,
+		},
+		Params: []command.Param{
+			{
+				Name:        argName,
+				Type:        command.String,
+				Description: sc.ArgHelp,
+				Required:    true,
+				Completer:   pluginCompleter(sc),
+			},
+			{Name: "description", Type: command.String, Description: "Override the default session description"},
+			{Name: "merge-on-close", Type: command.Bool, Description: "Auto-merge worktree into default branch on session close"},
+			{Name: "no-attach", Type: command.Bool, Description: "Create worktree but skip attaching"},
+		},
+		RunCLI: makePluginRunCLI(sc, argName),
+	}
+}
+
+// pluginCompleter returns a Completer that execs the user's `completion`
+// command and parses stdout as tab-separated `value\tdescription` lines.
+// Lines without a tab are treated as bare values with no description.
+// Any error returns nil to match the defensive style of completeGHPRs.
+func pluginCompleter(sc sweatfile.StartCommand) func() map[string]string {
+	if len(sc.Completion) == 0 {
+		return nil
+	}
+	return func() map[string]string {
+		cmd := exec.Command(sc.Completion[0], sc.Completion[1:]...)
+		out, err := cmd.Output()
+		if err != nil {
+			return nil
+		}
+		result := make(map[string]string)
+		scanner := bufio.NewScanner(bytes.NewReader(out))
+		for scanner.Scan() {
+			line := strings.TrimRight(scanner.Text(), "\r")
+			if line == "" {
+				continue
+			}
+			if tab := strings.IndexByte(line, '\t'); tab >= 0 {
+				result[line[:tab]] = line[tab+1:]
+			} else {
+				result[line] = ""
+			}
+		}
+		if len(result) == 0 {
+			return nil
+		}
+		return result
+	}
+}
+
+// makePluginRunCLI returns the RunCLI closure for a config-declared
+// `start-<name>` command. It validates the argument, runs the user's
+// `prompt` command to capture a markdown fragment, and then delegates to
+// the standard `attachSession` flow with a PluginFragment attached to the
+// ResolvedPath.
+func makePluginRunCLI(
+	sc sweatfile.StartCommand, argName string,
+) func(context.Context, json.RawMessage) error {
+	return func(_ context.Context, args json.RawMessage) error {
+		// Dynamic arg lookup: the JSON key matches sc.ArgName, which is
+		// user-provided, so we unmarshal into a map instead of a struct.
+		var raw map[string]json.RawMessage
+		_ = json.Unmarshal(args, &raw)
+
+		var p startArgs
+		_ = json.Unmarshal(args, &p)
+
+		var argValue string
+		if v, ok := raw[argName]; ok {
+			_ = json.Unmarshal(v, &argValue)
+		}
+		if argValue == "" {
+			return fmt.Errorf("start-%s requires a %s argument", sc.Name, argName)
+		}
+
+		if sc.ArgRegex != nil && *sc.ArgRegex != "" {
+			re, err := regexp.Compile(*sc.ArgRegex)
+			if err != nil {
+				return fmt.Errorf("start-%s: invalid arg-regex: %w", sc.Name, err)
+			}
+			if !re.MatchString(argValue) {
+				return fmt.Errorf(
+					"start-%s: %s %q does not match %s",
+					sc.Name, argName, argValue, *sc.ArgRegex,
+				)
+			}
+		}
+
+		content, err := runPluginPrompt(sc, argValue)
+		if err != nil {
+			return fmt.Errorf("start-%s prompt: %w", sc.Name, err)
+		}
+
+		cwd, err := os.Getwd()
+		if err != nil {
+			return err
+		}
+		repoPath, err := worktree.DetectRepo(cwd)
+		if err != nil {
+			return err
+		}
+
+		description := p.Description
+		if description == "" {
+			description = fmt.Sprintf("%s: %s", sc.Name, argValue)
+		}
+
+		resolvedPath, err := worktree.ResolvePath(repoPath, []string{description})
+		if err != nil {
+			return err
+		}
+
+		if strings.TrimSpace(content) != "" {
+			resolvedPath.PluginFragments = []prompt.PluginFragment{{
+				Name:    sc.Name,
+				Content: content,
+			}}
+		}
+
+		return attachSession(resolvedPath, p)
+	}
+}
+
+// runPluginPrompt executes the user's `prompt` command with `{arg}` tokens
+// substituted by the positional argument value. Substitution is a literal
+// string replace on each argv element — the command is exec'd directly (no
+// shell), so there is no injection surface beyond what the user's own argv
+// expressed. Users who want shell expansion must wrap in `sh -c`.
+func runPluginPrompt(sc sweatfile.StartCommand, argValue string) (string, error) {
+	if len(sc.Prompt) == 0 {
+		return "", nil
+	}
+	argv := make([]string, len(sc.Prompt))
+	for i, token := range sc.Prompt {
+		argv[i] = strings.ReplaceAll(token, "{arg}", argValue)
+	}
+	cmd := exec.Command(argv[0], argv[1:]...)
+	cmd.Stderr = os.Stderr
+	out, err := cmd.Output()
+	if err != nil {
+		return "", err
+	}
+	return string(out), nil
+}

--- a/cmd/spinclass/commands_plugin_test.go
+++ b/cmd/spinclass/commands_plugin_test.go
@@ -1,0 +1,128 @@
+package main
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/amarbel-llc/spinclass/internal/sweatfile"
+)
+
+func TestBuildPluginCommandParams(t *testing.T) {
+	regex := "^[A-Z]+-[0-9]+$"
+	sc := sweatfile.StartCommand{
+		Name:        "jira",
+		Description: "Start a JIRA session",
+		ArgName:     "ticket",
+		ArgHelp:     "JIRA ticket ID",
+		ArgRegex:    &regex,
+		Completion:  []string{"printf", "FOO-1\tfirst\nFOO-2\tsecond\n"},
+		Prompt:      []string{"printf", "%s", "# hi {arg}"},
+	}
+
+	cmd := buildPluginCommand("start-jira", sc)
+
+	if cmd.Name != "start-jira" {
+		t.Errorf("Name = %q, want start-jira", cmd.Name)
+	}
+	if cmd.Description.Short != "Start a JIRA session" {
+		t.Errorf("Short = %q", cmd.Description.Short)
+	}
+	if len(cmd.Params) != 4 {
+		t.Fatalf("expected 4 params (arg + 3 standard), got %d", len(cmd.Params))
+	}
+	arg := cmd.Params[0]
+	if arg.Name != "ticket" {
+		t.Errorf("arg.Name = %q, want ticket", arg.Name)
+	}
+	if !arg.Required {
+		t.Error("arg.Required should be true")
+	}
+	if arg.Completer == nil {
+		t.Error("arg.Completer should be non-nil")
+	}
+	wantNames := []string{"ticket", "description", "merge-on-close", "no-attach"}
+	for i, want := range wantNames {
+		if cmd.Params[i].Name != want {
+			t.Errorf("Params[%d].Name = %q, want %q", i, cmd.Params[i].Name, want)
+		}
+	}
+}
+
+func TestBuildPluginCommandDefaultsArgName(t *testing.T) {
+	sc := sweatfile.StartCommand{Name: "foo", Prompt: []string{"echo"}}
+	cmd := buildPluginCommand("start-foo", sc)
+	if cmd.Params[0].Name != "arg" {
+		t.Errorf("expected default arg name 'arg', got %q", cmd.Params[0].Name)
+	}
+	if cmd.Description.Short == "" {
+		t.Error("Short description should fall back to a non-empty default")
+	}
+}
+
+func TestPluginCompleterParsesTabSeparated(t *testing.T) {
+	sc := sweatfile.StartCommand{
+		Completion: []string{"printf", "%s", "FOO-1\tfirst issue\nFOO-2\tsecond issue\nFOO-3\n"},
+	}
+	completer := pluginCompleter(sc)
+	if completer == nil {
+		t.Fatal("expected non-nil completer")
+	}
+	result := completer()
+	if len(result) != 3 {
+		t.Fatalf("expected 3 results, got %d: %v", len(result), result)
+	}
+	if result["FOO-1"] != "first issue" {
+		t.Errorf("FOO-1 = %q, want 'first issue'", result["FOO-1"])
+	}
+	if result["FOO-3"] != "" {
+		t.Errorf("FOO-3 = %q, want empty (no tab)", result["FOO-3"])
+	}
+}
+
+func TestPluginCompleterNilWhenUnset(t *testing.T) {
+	if pluginCompleter(sweatfile.StartCommand{}) != nil {
+		t.Error("expected nil completer when sc.Completion is empty")
+	}
+}
+
+func TestPluginCompleterReturnsNilOnFailure(t *testing.T) {
+	sc := sweatfile.StartCommand{Completion: []string{"false"}}
+	completer := pluginCompleter(sc)
+	if completer == nil {
+		t.Fatal("expected non-nil completer")
+	}
+	if got := completer(); got != nil {
+		t.Errorf("expected nil on command failure, got %v", got)
+	}
+}
+
+func TestRunPluginPromptSubstitutesArg(t *testing.T) {
+	sc := sweatfile.StartCommand{
+		Prompt: []string{"printf", "%s", "# Hello {arg}\n"},
+	}
+	out, err := runPluginPrompt(sc, "world")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !strings.Contains(out, "# Hello world") {
+		t.Errorf("expected substituted output, got %q", out)
+	}
+}
+
+func TestRunPluginPromptPropagatesError(t *testing.T) {
+	sc := sweatfile.StartCommand{Prompt: []string{"false"}}
+	_, err := runPluginPrompt(sc, "x")
+	if err == nil {
+		t.Error("expected error from failing prompt command")
+	}
+}
+
+func TestRunPluginPromptEmptyPrompt(t *testing.T) {
+	out, err := runPluginPrompt(sweatfile.StartCommand{}, "x")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if out != "" {
+		t.Errorf("expected empty output, got %q", out)
+	}
+}

--- a/cmd/spinclass/commands_session.go
+++ b/cmd/spinclass/commands_session.go
@@ -54,20 +54,10 @@ func registerSessionCommands(app *command.App) {
 		RunCLI: runStartGHPR,
 	})
 
-	app.AddCommand(&command.Command{
-		Name: "start-gh_issue",
-		Description: command.Description{
-			Short: "Start a session with a GitHub issue",
-			Long:  "Create a new worktree session with GitHub issue context. The issue metadata is included in the session's system prompt.",
-		},
-		Params: []command.Param{
-			{Name: "issue", Type: command.String, Description: "Issue number", Required: true, Completer: completeGHIssues},
-			{Name: "description", Type: command.String, Description: "Freeform session description (quote multi-word strings)"},
-			{Name: "merge-on-close", Type: command.Bool, Description: "Auto-merge worktree into default branch on session close"},
-			{Name: "no-attach", Type: command.Bool, Description: "Create worktree but skip attaching"},
-		},
-		RunCLI: runStartGHIssue,
-	})
+	// `start-gh_issue` is registered dynamically from
+	// sweatfile.GetDefault()'s baked-in [[start-commands]] entry via
+	// registerPluginStartCommands(). See internal/sweatfile/sweatfile.go
+	// defaultStartCommands().
 
 	app.AddCommand(&command.Command{
 		Name: "resume",
@@ -196,29 +186,6 @@ func completeWorktreeTargets() map[string]string {
 	return result
 }
 
-func completeGHIssues() map[string]string {
-	out, err := exec.Command(
-		"gh", "issue", "list", "--json", "number,title", "--limit", "20",
-	).Output()
-	if err != nil {
-		return nil
-	}
-
-	var issues []struct {
-		Number int    `json:"number"`
-		Title  string `json:"title"`
-	}
-	if json.Unmarshal(out, &issues) != nil {
-		return nil
-	}
-
-	result := make(map[string]string, len(issues))
-	for _, i := range issues {
-		result[fmt.Sprintf("%d", i.Number)] = i.Title
-	}
-	return result
-}
-
 type startArgs struct {
 	globalArgs
 	Description  string `json:"description"`
@@ -332,42 +299,6 @@ func runStartGHPR(_ context.Context, args json.RawMessage) error {
 	if prData, prErr := prompt.FetchPR(p.PR, repoPath); prErr == nil {
 		resolvedPath.PR = &prData
 	}
-
-	return attachSession(resolvedPath, p.startArgs)
-}
-
-func runStartGHIssue(_ context.Context, args json.RawMessage) error {
-	var p struct {
-		startArgs
-		Issue string `json:"issue"`
-	}
-	_ = json.Unmarshal(args, &p)
-
-	cwd, err := os.Getwd()
-	if err != nil {
-		return err
-	}
-
-	repoPath, err := worktree.DetectRepo(cwd)
-	if err != nil {
-		return err
-	}
-
-	var descArgs []string
-	if p.Description != "" {
-		descArgs = []string{p.Description}
-	}
-
-	resolvedPath, err := worktree.ResolvePath(repoPath, descArgs)
-	if err != nil {
-		return err
-	}
-
-	issueData, err := prompt.FetchIssue(p.Issue, repoPath)
-	if err != nil {
-		return fmt.Errorf("fetching issue: %w", err)
-	}
-	resolvedPath.Issue = &issueData
 
 	return attachSession(resolvedPath, p.startArgs)
 }

--- a/internal/prompt/write.go
+++ b/internal/prompt/write.go
@@ -6,17 +6,25 @@ import (
 	"path/filepath"
 )
 
+// PluginFragment is a user-defined `start-<name>` command's markdown
+// contribution to the session's system_prompt_append.d/ directory.
+type PluginFragment struct {
+	Name    string // becomes the filename stem: 3-start-<Name>.md
+	Content string // written verbatim
+}
+
 type WriteOptions struct {
-	WorktreePath string
-	RepoPath     string
-	RemoteURL    string
-	Branch       string
-	SessionID    string
-	IsFork       bool
-	OwnerType    string
-	OwnerLogin   string
-	Issue        *IssueData
-	PR           *PRData
+	WorktreePath    string
+	RepoPath        string
+	RemoteURL       string
+	Branch          string
+	SessionID       string
+	IsFork          bool
+	OwnerType       string
+	OwnerLogin      string
+	Issue           *IssueData
+	PR              *PRData
+	PluginFragments []PluginFragment
 }
 
 func WriteSessionContext(opts WriteOptions) error {
@@ -62,6 +70,16 @@ func WriteSessionContext(opts WriteOptions) error {
 		}
 		filename := fmt.Sprintf("1-pr-%d.md", opts.PR.Number)
 		if err := os.WriteFile(filepath.Join(dir, filename), []byte(content), 0o644); err != nil {
+			return fmt.Errorf("writing %s: %w", filename, err)
+		}
+	}
+
+	for _, frag := range opts.PluginFragments {
+		if frag.Name == "" || frag.Content == "" {
+			continue
+		}
+		filename := fmt.Sprintf("3-start-%s.md", frag.Name)
+		if err := os.WriteFile(filepath.Join(dir, filename), []byte(frag.Content), 0o644); err != nil {
 			return fmt.Errorf("writing %s: %w", filename, err)
 		}
 	}

--- a/internal/shop/shop.go
+++ b/internal/shop/shop.go
@@ -55,7 +55,7 @@ func createWorktree(worktreePath worktree.ResolvedPath, verbose bool) (bool, err
 
 	if _, err := os.Stat(worktreePath.AbsPath); os.IsNotExist(err) {
 		existed = false
-		result, err := worktree.Create(worktreePath.RepoPath, worktreePath.AbsPath, worktreePath.ExistingBranch, worktreePath.Issue, worktreePath.PR)
+		result, err := worktree.Create(worktreePath.RepoPath, worktreePath.AbsPath, worktreePath.ExistingBranch, worktreePath.Issue, worktreePath.PR, worktreePath.PluginFragments)
 		if err != nil {
 			return false, err
 		}

--- a/internal/sweatfile/hierarchy.go
+++ b/internal/sweatfile/hierarchy.go
@@ -230,5 +230,24 @@ func (sf Sweatfile) MergeWith(other Sweatfile) Sweatfile {
 		}
 	}
 
+	// [[start-commands]] — append across levels, then dedupe by Name with
+	// the most-specific (last) definition winning. Entries within a single
+	// level preserve their relative order; cross-level overrides keep the
+	// position of the first occurrence so iteration order stays stable.
+	if len(other.StartCommands) > 0 {
+		index := make(map[string]int, len(merged.StartCommands))
+		for i, sc := range merged.StartCommands {
+			index[sc.Name] = i
+		}
+		for _, sc := range other.StartCommands {
+			if i, ok := index[sc.Name]; ok {
+				merged.StartCommands[i] = sc
+				continue
+			}
+			index[sc.Name] = len(merged.StartCommands)
+			merged.StartCommands = append(merged.StartCommands, sc)
+		}
+	}
+
 	return merged
 }

--- a/internal/sweatfile/sweatfile.go
+++ b/internal/sweatfile/sweatfile.go
@@ -38,13 +38,26 @@ type Hooks struct {
 	ToolUseLog           *bool   `toml:"tool-use-log"`
 }
 
+// StartCommand declares a user-defined `sc start-<name>` subcommand.
+// See CLAUDE.md "Custom start commands" for the full schema.
+type StartCommand struct {
+	Name        string   `toml:"name"`
+	Description string   `toml:"description"`
+	ArgName     string   `toml:"arg-name"`
+	ArgHelp     string   `toml:"arg-help"`
+	ArgRegex    *string  `toml:"arg-regex"`
+	Completion  []string `toml:"completion"`
+	Prompt      []string `toml:"prompt"`
+}
+
 //go:generate tommy generate
 type Sweatfile struct {
-	Claude       *Claude       `toml:"claude"`
-	Git          *Git          `toml:"git"`
-	Direnv       *Direnv       `toml:"direnv"`
-	Hooks        *Hooks        `toml:"hooks"`
-	SessionEntry *SessionEntry `toml:"session-entry"`
+	Claude        *Claude        `toml:"claude"`
+	Git           *Git           `toml:"git"`
+	Direnv        *Direnv        `toml:"direnv"`
+	Hooks         *Hooks         `toml:"hooks"`
+	SessionEntry  *SessionEntry  `toml:"session-entry"`
+	StartCommands []StartCommand `toml:"start-commands"`
 }
 
 func (sf Sweatfile) StopHookCommand() *string {
@@ -110,7 +123,8 @@ func (sf Sweatfile) SessionResume() []string {
 // sweatfile config.
 func GetDefault() Sweatfile {
 	sf := Sweatfile{
-		Git: &Git{Excludes: []string{".worktrees/", ".spinclass/", ".mcp.json"}},
+		Git:           &Git{Excludes: []string{".worktrees/", ".spinclass/", ".mcp.json"}},
+		StartCommands: defaultStartCommands(),
 	}
 
 	if home, err := os.UserHomeDir(); err == nil && home != "" {
@@ -119,6 +133,46 @@ func GetDefault() Sweatfile {
 	}
 
 	return sf
+}
+
+// defaultStartCommands returns the baked-in `[[start-commands]]` entries
+// that ship with every spinclass install. These exist as tracer bullets:
+// commands that used to be hard-coded Go handlers are now declared via the
+// same config mechanism users have for custom start-* commands.
+func defaultStartCommands() []StartCommand {
+	issueRegex := `^[0-9]+$`
+	return []StartCommand{
+		{
+			Name:        "gh_issue",
+			Description: "Start a session with a GitHub issue",
+			ArgName:     "issue",
+			ArgHelp:     "Issue number",
+			ArgRegex:    &issueRegex,
+			Completion: []string{
+				"sh", "-c",
+				`gh issue list --json number,title --limit 20 2>/dev/null | ` +
+					`jq -r '.[] | "\(.number)\t\(.title)"' 2>/dev/null`,
+			},
+			Prompt: []string{
+				"sh", "-c",
+				`gh issue view {arg} --template '# GitHub Issue Context
+
+This session is working on the following GitHub issue.
+
+## Issue #{{.number}}: {{.title}}
+- **State:** {{.state}}
+{{- if .labels}}
+- **Labels:** {{range $i, $l := .labels}}{{if $i}}, {{end}}{{$l.name}}{{end}}
+{{- end}}
+- **URL:** {{.url}}
+
+## Description
+
+{{.body}}
+'`,
+			},
+		},
+	}
 }
 
 func collectSystemPromptAppend(cwd string) (string, error) {

--- a/internal/sweatfile/sweatfile_test.go
+++ b/internal/sweatfile/sweatfile_test.go
@@ -1225,3 +1225,134 @@ func TestMergeSessionNilInherit(t *testing.T) {
 		t.Errorf("expected SessionEntry.Start to be inherited, got %v", merged.SessionEntry)
 	}
 }
+
+func TestParseStartCommands(t *testing.T) {
+	input := `
+[[start-commands]]
+name = "jira"
+description = "Start for a JIRA ticket"
+arg-name = "ticket"
+arg-help = "JIRA ticket ID"
+arg-regex = "^[A-Z]+-[0-9]+$"
+completion = ["jira", "list"]
+prompt = ["jira", "show", "{arg}"]
+`
+	doc, err := Parse([]byte(input))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	sf := doc.Data()
+	if len(sf.StartCommands) != 1 {
+		t.Fatalf("expected 1 start-command, got %d", len(sf.StartCommands))
+	}
+	sc := sf.StartCommands[0]
+	if sc.Name != "jira" {
+		t.Errorf("Name = %q, want jira", sc.Name)
+	}
+	if sc.ArgName != "ticket" {
+		t.Errorf("ArgName = %q, want ticket", sc.ArgName)
+	}
+	if sc.ArgRegex == nil || *sc.ArgRegex != "^[A-Z]+-[0-9]+$" {
+		t.Errorf("ArgRegex = %v, want ^[A-Z]+-[0-9]+$", sc.ArgRegex)
+	}
+	if len(sc.Completion) != 2 || sc.Completion[0] != "jira" {
+		t.Errorf("Completion = %v", sc.Completion)
+	}
+	if len(sc.Prompt) != 3 || sc.Prompt[2] != "{arg}" {
+		t.Errorf("Prompt = %v", sc.Prompt)
+	}
+}
+
+func TestParseStartCommandsMultiple(t *testing.T) {
+	input := `
+[[start-commands]]
+name = "jira"
+prompt = ["echo", "jira"]
+
+[[start-commands]]
+name = "linear"
+prompt = ["echo", "linear"]
+`
+	doc, err := Parse([]byte(input))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	sf := doc.Data()
+	if len(sf.StartCommands) != 2 {
+		t.Fatalf("expected 2 start-commands, got %d", len(sf.StartCommands))
+	}
+	if sf.StartCommands[0].Name != "jira" || sf.StartCommands[1].Name != "linear" {
+		t.Errorf("order = %q, %q", sf.StartCommands[0].Name, sf.StartCommands[1].Name)
+	}
+}
+
+func TestMergeStartCommandsAppend(t *testing.T) {
+	base := Sweatfile{
+		StartCommands: []StartCommand{
+			{Name: "jira", Prompt: []string{"echo", "base"}},
+		},
+	}
+	repo := Sweatfile{
+		StartCommands: []StartCommand{
+			{Name: "linear", Prompt: []string{"echo", "linear"}},
+		},
+	}
+	merged := base.MergeWith(repo)
+	if len(merged.StartCommands) != 2 {
+		t.Fatalf("expected 2 entries, got %d", len(merged.StartCommands))
+	}
+	if merged.StartCommands[0].Name != "jira" || merged.StartCommands[1].Name != "linear" {
+		t.Errorf("order broken: %v", merged.StartCommands)
+	}
+}
+
+func TestMergeStartCommandsOverrideByName(t *testing.T) {
+	base := Sweatfile{
+		StartCommands: []StartCommand{
+			{Name: "jira", Prompt: []string{"echo", "base"}},
+			{Name: "linear", Prompt: []string{"echo", "linear"}},
+		},
+	}
+	repo := Sweatfile{
+		StartCommands: []StartCommand{
+			{Name: "jira", Prompt: []string{"echo", "override"}},
+		},
+	}
+	merged := base.MergeWith(repo)
+	if len(merged.StartCommands) != 2 {
+		t.Fatalf("expected 2 entries after override, got %d", len(merged.StartCommands))
+	}
+	// Override keeps the slot position.
+	if merged.StartCommands[0].Name != "jira" {
+		t.Errorf("expected jira to stay at slot 0, got %v", merged.StartCommands)
+	}
+	if got := merged.StartCommands[0].Prompt; len(got) != 2 || got[1] != "override" {
+		t.Errorf("expected override prompt, got %v", got)
+	}
+}
+
+func TestGetDefaultShipsGhIssueStartCommand(t *testing.T) {
+	def := GetDefault()
+	var found *StartCommand
+	for i := range def.StartCommands {
+		if def.StartCommands[i].Name == "gh_issue" {
+			found = &def.StartCommands[i]
+			break
+		}
+	}
+	if found == nil {
+		t.Fatal("expected gh_issue entry in GetDefault().StartCommands")
+	}
+	if found.ArgName != "issue" {
+		t.Errorf("ArgName = %q, want issue", found.ArgName)
+	}
+	if found.ArgRegex == nil || *found.ArgRegex != "^[0-9]+$" {
+		t.Errorf("ArgRegex = %v, want ^[0-9]+$", found.ArgRegex)
+	}
+	if len(found.Prompt) == 0 {
+		t.Error("Prompt must be non-empty")
+	}
+	if len(found.Completion) == 0 {
+		t.Error("Completion must be non-empty")
+	}
+}

--- a/internal/sweatfile/sweatfile_tommy.go
+++ b/internal/sweatfile/sweatfile_tommy.go
@@ -172,8 +172,97 @@ func DecodeSweatfile(input []byte) (*SweatfileDocument, error) {
 			d.data.SessionEntry = sessionEntryVal
 		}
 	}
+	decodeStartCommands(d.cstDoc, &d.data, d.consumed, "")
 
 	return d, nil
+}
+
+// decodeStartCommands reads all [[start-commands]] entries from the document
+// and populates data.StartCommands. Mirrors the per-field GetFromContainer
+// pattern tommy generates for regular tables.
+func decodeStartCommands(
+	doc *document.Document,
+	data *Sweatfile,
+	consumed map[string]bool,
+	keyPrefix string,
+) {
+	nodes := doc.FindArrayTableNodes("start-commands")
+	if len(nodes) == 0 {
+		return
+	}
+	consumed[keyPrefix+"start-commands"] = true
+	data.StartCommands = make([]StartCommand, len(nodes))
+	for i, node := range nodes {
+		if v, err := document.GetFromContainer[string](doc, node, "name"); err == nil {
+			data.StartCommands[i].Name = v
+			consumed[keyPrefix+"start-commands.name"] = true
+		}
+		if v, err := document.GetFromContainer[string](doc, node, "description"); err == nil {
+			data.StartCommands[i].Description = v
+			consumed[keyPrefix+"start-commands.description"] = true
+		}
+		if v, err := document.GetFromContainer[string](doc, node, "arg-name"); err == nil {
+			data.StartCommands[i].ArgName = v
+			consumed[keyPrefix+"start-commands.arg-name"] = true
+		}
+		if v, err := document.GetFromContainer[string](doc, node, "arg-help"); err == nil {
+			data.StartCommands[i].ArgHelp = v
+			consumed[keyPrefix+"start-commands.arg-help"] = true
+		}
+		if v, err := document.GetFromContainer[string](doc, node, "arg-regex"); err == nil {
+			data.StartCommands[i].ArgRegex = &v
+			consumed[keyPrefix+"start-commands.arg-regex"] = true
+		}
+		if v, err := document.GetFromContainer[[]string](doc, node, "completion"); err == nil {
+			data.StartCommands[i].Completion = v
+			consumed[keyPrefix+"start-commands.completion"] = true
+		}
+		if v, err := document.GetFromContainer[[]string](doc, node, "prompt"); err == nil {
+			data.StartCommands[i].Prompt = v
+			consumed[keyPrefix+"start-commands.prompt"] = true
+		}
+	}
+}
+
+func encodeStartCommands(doc *document.Document, data *Sweatfile) error {
+	for i := range data.StartCommands {
+		entry := doc.AppendArrayTableEntry("start-commands")
+		sc := &data.StartCommands[i]
+		if err := doc.SetInContainer(entry, "name", sc.Name); err != nil {
+			return err
+		}
+		if sc.Description != "" {
+			if err := doc.SetInContainer(entry, "description", sc.Description); err != nil {
+				return err
+			}
+		}
+		if sc.ArgName != "" {
+			if err := doc.SetInContainer(entry, "arg-name", sc.ArgName); err != nil {
+				return err
+			}
+		}
+		if sc.ArgHelp != "" {
+			if err := doc.SetInContainer(entry, "arg-help", sc.ArgHelp); err != nil {
+				return err
+			}
+		}
+		if sc.ArgRegex != nil {
+			if err := doc.SetInContainer(entry, "arg-regex", *sc.ArgRegex); err != nil {
+				return err
+			}
+		}
+		if sc.Completion != nil {
+			if err := doc.SetInContainer(entry, "completion", sc.Completion); err != nil {
+				return err
+			}
+		}
+		if sc.Prompt != nil {
+			if err := doc.SetInContainer(entry, "prompt", sc.Prompt); err != nil {
+				return err
+			}
+		}
+	}
+	return nil
 }
 
 func (d *SweatfileDocument) Data() *Sweatfile { return &d.data }
@@ -252,6 +341,9 @@ func (d *SweatfileDocument) Encode() ([]byte, error) {
 		if err := d.cstDoc.SetInContainer(tableNode, "resume", d.data.SessionEntry.Resume); err != nil {
 			return nil, err
 		}
+	}
+	if err := encodeStartCommands(d.cstDoc, &d.data); err != nil {
+		return nil, err
 	}
 
 	return d.cstDoc.Bytes(), nil
@@ -421,6 +513,9 @@ func DecodeSweatfileInto(data *Sweatfile, doc *document.Document, container *cst
 			data.SessionEntry = sessionEntryVal
 		}
 	}
+	// `[[start-commands]]` is only meaningful at document root, not nested
+	// inside an arbitrary container, so DecodeSweatfileInto does not emit it.
+	_ = container
 
 	return nil
 }
@@ -499,6 +594,9 @@ func EncodeSweatfileFrom(data *Sweatfile, doc *document.Document, container *cst
 		if err := doc.SetInContainer(tableNode, "resume", data.SessionEntry.Resume); err != nil {
 			return err
 		}
+	}
+	if err := encodeStartCommands(doc, data); err != nil {
+		return err
 	}
 
 	return nil

--- a/internal/validate/validate.go
+++ b/internal/validate/validate.go
@@ -6,11 +6,14 @@ import (
 	"io"
 	"os"
 	"path/filepath"
+	"regexp"
 	"strings"
 
 	"github.com/amarbel-llc/spinclass/internal/sweatfile"
 	"github.com/amarbel-llc/spinclass/internal/tap"
 )
+
+var startCommandNameRE = regexp.MustCompile(`^[a-z][a-z0-9_-]*$`)
 
 // RunString executes the same logic as Run but captures output into a string,
 // returning (output, exitCode). Used by handlers that need to return output as
@@ -95,6 +98,63 @@ func CheckClaudeAllow(sf sweatfile.Sweatfile) []Issue {
 				Field:    "claude-allow",
 				Value:    rule,
 			})
+		}
+	}
+	return issues
+}
+
+func CheckStartCommands(sf sweatfile.Sweatfile) []Issue {
+	var issues []Issue
+	seen := make(map[string]bool, len(sf.StartCommands))
+	for _, sc := range sf.StartCommands {
+		if sc.Name == "" {
+			issues = append(issues, Issue{
+				Message:  "start-command entry missing `name`",
+				Severity: SeverityError,
+				Field:    "start-commands.name",
+			})
+			continue
+		}
+		if !startCommandNameRE.MatchString(sc.Name) {
+			issues = append(issues, Issue{
+				Message: fmt.Sprintf(
+					"invalid start-command name %q (must match %s)",
+					sc.Name, startCommandNameRE.String(),
+				),
+				Severity: SeverityError,
+				Field:    "start-commands.name",
+				Value:    sc.Name,
+			})
+		}
+		if seen[sc.Name] {
+			issues = append(issues, Issue{
+				Message:  fmt.Sprintf("duplicate start-command %q in this file", sc.Name),
+				Severity: SeverityError,
+				Field:    "start-commands.name",
+				Value:    sc.Name,
+			})
+		}
+		seen[sc.Name] = true
+		if len(sc.Prompt) == 0 {
+			issues = append(issues, Issue{
+				Message:  fmt.Sprintf("start-command %q requires a non-empty `prompt`", sc.Name),
+				Severity: SeverityError,
+				Field:    "start-commands.prompt",
+				Value:    sc.Name,
+			})
+		}
+		if sc.ArgRegex != nil && *sc.ArgRegex != "" {
+			if _, err := regexp.Compile(*sc.ArgRegex); err != nil {
+				issues = append(issues, Issue{
+					Message: fmt.Sprintf(
+						"start-command %q has invalid arg-regex: %s",
+						sc.Name, err,
+					),
+					Severity: SeverityError,
+					Field:    "start-commands.arg-regex",
+					Value:    *sc.ArgRegex,
+				})
+			}
 		}
 	}
 	return issues
@@ -276,6 +336,23 @@ func Run(w io.Writer, home, repoDir string) int {
 				}
 			} else {
 				sub.Ok("git-excludes valid")
+			}
+		}
+
+		if len(src.File.StartCommands) > 0 {
+			if issues := CheckStartCommands(src.File); len(issues) > 0 {
+				for _, iss := range issues {
+					diag := map[string]string{
+						"severity": iss.Severity,
+						"message":  iss.Message,
+					}
+					if iss.Value != "" {
+						diag["value"] = iss.Value
+					}
+					sub.NotOk("start-commands valid", diag)
+				}
+			} else {
+				sub.Ok("start-commands valid")
 			}
 		}
 

--- a/internal/validate/validate_test.go
+++ b/internal/validate/validate_test.go
@@ -142,3 +142,65 @@ stop = "just build test"
 		t.Errorf("expected no issues for [hooks] table, got %v", issues)
 	}
 }
+
+func TestCheckStartCommandsValid(t *testing.T) {
+	sf := sweatfile.Sweatfile{
+		StartCommands: []sweatfile.StartCommand{
+			{
+				Name:   "jira",
+				Prompt: []string{"echo", "hi"},
+			},
+		},
+	}
+	if issues := CheckStartCommands(sf); len(issues) != 0 {
+		t.Errorf("expected no issues, got %v", issues)
+	}
+}
+
+func TestCheckStartCommandsMissingPrompt(t *testing.T) {
+	sf := sweatfile.Sweatfile{
+		StartCommands: []sweatfile.StartCommand{{Name: "jira"}},
+	}
+	issues := CheckStartCommands(sf)
+	if len(issues) != 1 || issues[0].Field != "start-commands.prompt" {
+		t.Fatalf("expected 1 prompt issue, got %v", issues)
+	}
+}
+
+func TestCheckStartCommandsBadName(t *testing.T) {
+	sf := sweatfile.Sweatfile{
+		StartCommands: []sweatfile.StartCommand{
+			{Name: "Bad Name", Prompt: []string{"echo"}},
+		},
+	}
+	issues := CheckStartCommands(sf)
+	if len(issues) != 1 || issues[0].Field != "start-commands.name" {
+		t.Fatalf("expected 1 name issue, got %v", issues)
+	}
+}
+
+func TestCheckStartCommandsDuplicateName(t *testing.T) {
+	sf := sweatfile.Sweatfile{
+		StartCommands: []sweatfile.StartCommand{
+			{Name: "jira", Prompt: []string{"echo"}},
+			{Name: "jira", Prompt: []string{"echo"}},
+		},
+	}
+	issues := CheckStartCommands(sf)
+	if len(issues) != 1 || issues[0].Field != "start-commands.name" {
+		t.Fatalf("expected 1 duplicate issue, got %v", issues)
+	}
+}
+
+func TestCheckStartCommandsBadRegex(t *testing.T) {
+	bad := "["
+	sf := sweatfile.Sweatfile{
+		StartCommands: []sweatfile.StartCommand{
+			{Name: "jira", Prompt: []string{"echo"}, ArgRegex: &bad},
+		},
+	}
+	issues := CheckStartCommands(sf)
+	if len(issues) != 1 || issues[0].Field != "start-commands.arg-regex" {
+		t.Fatalf("expected 1 regex issue, got %v", issues)
+	}
+}

--- a/internal/worktree/worktree.go
+++ b/internal/worktree/worktree.go
@@ -15,14 +15,15 @@ import (
 const WorktreesDir = ".worktrees"
 
 type ResolvedPath struct {
-	AbsPath        string            // absolute filesystem path to the worktree
-	RepoPath       string            // absolute path to the parent git repo
-	SessionKey     string            // key for zmx/executor sessions (<repo-dirname>/<branch>)
-	Branch         string            // branch name
-	Description    string            // freeform session description
-	ExistingBranch string            // non-empty when an existing branch was detected
-	Issue          *prompt.IssueData // optional issue context for session prompt
-	PR             *prompt.PRData    // optional PR context for session prompt
+	AbsPath         string                  // absolute filesystem path to the worktree
+	RepoPath        string                  // absolute path to the parent git repo
+	SessionKey      string                  // key for zmx/executor sessions (<repo-dirname>/<branch>)
+	Branch          string                  // branch name
+	Description     string                  // freeform session description
+	ExistingBranch  string                  // non-empty when an existing branch was detected
+	Issue           *prompt.IssueData       // optional issue context for session prompt
+	PR              *prompt.PRData          // optional PR context for session prompt
+	PluginFragments []prompt.PluginFragment // optional user-defined start-command fragments
 }
 
 // ResolvePath resolves a worktree target relative to a git repo.
@@ -127,6 +128,7 @@ func isCeiling(dir string, ceilings []string) bool {
 func Create(
 	repoPath, worktreePath, existingBranch string,
 	issue *prompt.IssueData, pr *prompt.PRData,
+	pluginFragments []prompt.PluginFragment,
 ) (sweatfile.Hierarchy, error) {
 	home, err := os.UserHomeDir()
 	if err != nil {
@@ -161,6 +163,7 @@ func Create(
 		worktreePath,
 		issue,
 		pr,
+		pluginFragments,
 	)
 }
 
@@ -187,7 +190,7 @@ func CreateFrom(
 		return sweetfile, fmt.Errorf("loading sweatfile: %w", err)
 	}
 
-	return sweetfile, applyWorktreeConfig(home, sweetfile, repoPath, newPath, nil, nil)
+	return sweetfile, applyWorktreeConfig(home, sweetfile, repoPath, newPath, nil, nil, nil)
 }
 
 // applyWorktreeConfig excludes .worktrees from git, loads and applies
@@ -200,6 +203,7 @@ func applyWorktreeConfig(
 	worktreePath string,
 	issue *prompt.IssueData,
 	pr *prompt.PRData,
+	pluginFragments []prompt.PluginFragment,
 ) error {
 	merged := sweetfile.Merged.MergeWith(sweatfile.GetDefault())
 	if err := applyGitExcludes(repoPath, merged.GitExcludes()); err != nil {
@@ -225,16 +229,17 @@ func applyWorktreeConfig(
 	repoDirname := filepath.Base(repoPath)
 
 	writeOpts := prompt.WriteOptions{
-		WorktreePath: worktreePath,
-		RepoPath:     repoPath,
-		RemoteURL:    remoteURL,
-		Branch:       branch,
-		SessionID:    repoDirname + "/" + branch,
-		IsFork:       isFork,
-		OwnerType:    ownerType,
-		OwnerLogin:   ownerLogin,
-		Issue:        issue,
-		PR:           pr,
+		WorktreePath:    worktreePath,
+		RepoPath:        repoPath,
+		RemoteURL:       remoteURL,
+		Branch:          branch,
+		SessionID:       repoDirname + "/" + branch,
+		IsFork:          isFork,
+		OwnerType:       ownerType,
+		OwnerLogin:      ownerLogin,
+		Issue:           issue,
+		PR:              pr,
+		PluginFragments: pluginFragments,
 	}
 
 	if err := prompt.WriteSessionContext(writeOpts); err != nil {


### PR DESCRIPTION
Add a new `[[start-commands]]` array of tables to the sweatfile schema
that lets users declare custom `sc start-<name>` subcommands without
touching Go code. Each entry gets a positional arg with optional
regex validation, a shell-exec'd tab completer, and a shell-exec'd
prompt command whose stdout is written to
`<worktree>/.spinclass/system_prompt_append.d/3-start-<name>.md` and
picked up automatically by the existing `--append-system-prompt` flow.

Entries merge across the sweatfile hierarchy (global -> parent -> repo)
with later definitions overriding earlier ones by `name`. Collisions
with built-in commands are silently skipped at registration time.

As a tracer bullet for the new mechanism, `start-gh_issue` is migrated
out of Go and into `sweatfile.GetDefault()` as a baked-in entry that
ships with every install. The hard-coded `runStartGHIssue` /
`completeGHIssues` handlers are removed. `start-gh_pr` stays built-in
for now because it also does branch resolution and description
override, which the initial schema does not yet cover.

- internal/sweatfile: StartCommand struct + hierarchy merge + hand-
  patched tommy decode/encode (regenerating via `tommy generate` would
  introduce an unrelated dotenv regression in this tommy version).
- internal/validate: `CheckStartCommands` enforces name format, duplicate
  names within a file, non-empty prompt, and compilable arg-regex.
- internal/prompt, internal/worktree, internal/shop: thread
  `PluginFragments` through `WriteOptions` / `ResolvedPath` /
  `worktree.Create` alongside the existing `Issue` / `PR` plumbing.
- cmd/spinclass/commands_plugin.go: dynamic registration that loads the
  hierarchy from cwd at CLI startup (best-effort; silent outside a repo)
  and for each entry builds a command with a closure that validates
  the arg, runs the prompt command with `{arg}` substituted literally,
  and attaches the fragment to `ResolvedPath`.

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>