### PR TITLE
check: ndjson-crap pre-merge output format via crap's ndjsoncrap

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -351,6 +351,9 @@ and fish included.
 
 Module: `github.com/amarbel-llc/spinclass`. Key dependencies: -
 `github.com/amarbel-llc/tap/go` --- TAP-14 output library -
+`github.com/amarbel-llc/crap/go-crap` --- ndjson-crap reader (consumed by the
+`ndjson-crap` pre-merge-output-format, where the hook emits canonical
+ndjson-crap directly; see `internal/check`) -
 `github.com/amarbel-llc/purse-first/libs/go-mcp` --- MCP server framework -
 `github.com/amarbel-llc/tommy` --- TOML library - `github.com/spf13/cobra` ---
 CLI framework

--- a/go.mod
+++ b/go.mod
@@ -17,6 +17,7 @@ require (
 )
 
 require (
+	github.com/amarbel-llc/crap/go-crap v0.0.0-00010101000000-000000000000
 	github.com/amarbel-llc/purse-first/libs/dewey v0.1.8 // indirect
 	github.com/atotto/clipboard v0.1.4 // indirect
 	github.com/aymanbagabas/go-osc52/v2 v2.0.1 // indirect
@@ -55,3 +56,5 @@ require (
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 	mvdan.cc/sh/v3 v3.13.1 // indirect
 )
+
+replace github.com/amarbel-llc/crap/go-crap => ../crap/go-crap

--- a/internal/check/check.go
+++ b/internal/check/check.go
@@ -14,6 +14,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/amarbel-llc/crap/go-crap/ndjsoncrap"
 	"github.com/amarbel-llc/spinclass/internal/embeds"
 	"github.com/amarbel-llc/spinclass/internal/git"
 	"github.com/amarbel-llc/spinclass/internal/madder"
@@ -44,7 +45,7 @@ type BlobLink struct {
 // ResourceLinkContent block. Anything other than "tap-ndjson" maps to
 // "text/plain" (matching the format=raw default).
 func mimeTypeForFormat(format string) string {
-	if format == "tap-ndjson" {
+	if format == "tap-ndjson" || format == "ndjson-crap" {
 		return "application/x-ndjson"
 	}
 	return "text/plain"
@@ -241,19 +242,27 @@ func runHookCompactContext(ctx context.Context, tw *tap.Writer, hierarchy sweatf
 	// ring is the fallback visibility for failures the parser can't surface.
 	ring := newTailRingWriter(15)
 
+	// Structured formats buffer hook stdout and store structured output to
+	// madder after the hook exits; "raw" streams straight through.
+	//   - tap-ndjson : hook emits TAP-14 text, spinclass converts via tap's
+	//                  aggregator and stores the ndjson.
+	//   - ndjson-crap: hook emits canonical ndjson-crap directly (the crap
+	//                  wire format); spinclass stores it verbatim and parses
+	//                  it via crap's ndjsoncrap reader for the failure summary.
+	structured := format == "tap-ndjson" || format == "ndjson-crap"
+
 	var (
 		madderStdin   io.WriteCloser
 		finishMadder  func() (string, error)
-		hookStdoutBuf bytes.Buffer // populated only when format == "tap-ndjson"
+		hookStdoutBuf bytes.Buffer // populated only for structured formats
 	)
 
-	if format == "tap-ndjson" {
-		// Buffer hook stdout fully; we write the parsed ndjson to
-		// madder below, not the raw stream. madderStdin and
-		// finishMadder are placeholders here so the shared variable
-		// shape compiles for both paths — the real madder.Write for
-		// this format happens after the hook exits and stdout is
-		// parsed (see the post-hook block below).
+	if structured {
+		// Buffer hook stdout fully; we write to madder below, not the raw
+		// stream. madderStdin and finishMadder are placeholders here so the
+		// shared variable shape compiles for both paths — the real
+		// madder.Write happens after the hook exits (see the post-hook
+		// switch below).
 		madderStdin = nopWriteCloser{io.Discard}
 		finishMadder = func() (string, error) { return "", nil }
 	} else {
@@ -268,7 +277,7 @@ func runHookCompactContext(ctx context.Context, tw *tap.Writer, hierarchy sweatf
 	}
 
 	var sink io.Writer
-	if format == "tap-ndjson" {
+	if structured {
 		sink = io.MultiWriter(&hookStdoutBuf, ring)
 	} else {
 		sink = io.MultiWriter(madderStdin, ring)
@@ -284,11 +293,13 @@ func runHookCompactContext(ctx context.Context, tw *tap.Writer, hierarchy sweatf
 	var (
 		blobID    string
 		madderErr error
-		parsed    ndjson.Output
+		parsed    ndjson.Output     // tap-ndjson path
+		crapTests []ndjsoncrap.Test // ndjson-crap path
 		hasParse  bool
 	)
 
-	if format == "tap-ndjson" {
+	switch format {
+	case "tap-ndjson":
 		rd := reader.NewReader(&hookStdoutBuf)
 		agg := ndjson.NewAggregator()
 		for {
@@ -316,7 +327,29 @@ func runHookCompactContext(ctx context.Context, tw *tap.Writer, hierarchy sweatf
 			}
 			blobID = id
 		}
-	} else {
+
+	case "ndjson-crap":
+		// The hook already emitted canonical ndjson-crap. Parse it (for the
+		// failure summary) and store the stream verbatim — no re-encoding.
+		crapTests = collectCrapTests(bytes.NewReader(hookStdoutBuf.Bytes()))
+		hasParse = len(crapTests) > 0
+
+		ms, fm, mErr := madder.Write(wtPath, embeds.MadderBin())
+		if mErr != nil {
+			madderErr = mErr
+		} else if _, wErr := ms.Write(hookStdoutBuf.Bytes()); wErr != nil {
+			madderErr = wErr
+			_ = ms.Close()
+		} else {
+			_ = ms.Close()
+			id, fErr := fm()
+			if fErr != nil {
+				madderErr = fErr
+			}
+			blobID = id
+		}
+
+	default:
 		_ = madderStdin.Close()
 		blobID, madderErr = finishMadder()
 	}
@@ -342,14 +375,17 @@ func runHookCompactContext(ctx context.Context, tw *tap.Writer, hierarchy sweatf
 	//  - format=tap-ndjson, success   → neither tail nor failure
 	//  - format=tap-ndjson, fail+rec  → failure (built from parsed)
 	//  - format=tap-ndjson, fail+!rec → tail (fallback)
-	if format == "raw" {
+	if !structured {
 		if hookErr != nil {
 			extras["tail"] = ring.Tail()
 		}
 	} else if hookErr != nil {
-		if hasParse {
+		switch {
+		case format == "tap-ndjson" && hasParse:
 			extras["failure"] = buildFailureSummary(parsed)
-		} else {
+		case format == "ndjson-crap" && hasParse:
+			extras["failure"] = buildFailureSummaryCrap(crapTests)
+		default:
 			extras["tail"] = ring.Tail()
 		}
 	}
@@ -382,6 +418,48 @@ func runHookCompactContext(ctx context.Context, tw *tap.Writer, hierarchy sweatf
 func buildFailureSummary(out ndjson.Output) string {
 	var b strings.Builder
 	for _, r := range out.Records {
+		if r.OK || r.Directive != nil {
+			continue
+		}
+		fmt.Fprintf(&b, "#%d %s", r.N, r.Description)
+		if msg, ok := r.Diagnostic["message"].(string); ok && msg != "" {
+			fmt.Fprintf(&b, ": %s", msg)
+		}
+		b.WriteByte('\n')
+		if r.Output != nil && *r.Output != "" {
+			for _, line := range strings.Split(strings.TrimRight(*r.Output, "\n"), "\n") {
+				fmt.Fprintf(&b, "  %s\n", line)
+			}
+		}
+	}
+	return strings.TrimRight(b.String(), "\n")
+}
+
+// collectCrapTests decodes an ndjson-crap stream and returns its top-level
+// test records (the records the failure summary reports on). Non-test
+// records (plan/summary/header/execution-family) are ignored; decoding stops
+// at EOF or the first undecodable line.
+func collectCrapTests(r io.Reader) []ndjsoncrap.Test {
+	rd := ndjsoncrap.NewReader(r)
+	var tests []ndjsoncrap.Test
+	for {
+		rec, err := rd.Next()
+		if err != nil {
+			break
+		}
+		if t, ok := rec.(ndjsoncrap.Test); ok {
+			tests = append(tests, t)
+		}
+	}
+	return tests
+}
+
+// buildFailureSummaryCrap is the ndjson-crap analogue of buildFailureSummary:
+// one line per genuinely-failing top-level test record (!OK && no directive),
+// with its diagnostic message and any captured output indented beneath.
+func buildFailureSummaryCrap(tests []ndjsoncrap.Test) string {
+	var b strings.Builder
+	for _, r := range tests {
 		if r.OK || r.Directive != nil {
 			continue
 		}

--- a/internal/check/check_test.go
+++ b/internal/check/check_test.go
@@ -381,6 +381,74 @@ func TestRunHookCompactShape_TapNDJSONFailure(t *testing.T) {
 	}
 }
 
+func TestRunHookCompactShape_NdjsonCrapSuccess(t *testing.T) {
+	_, _, wtPath := setupRepoWithWorktree(t, "feature-ndjson-crap-success")
+	_, stdinCapture := withFakeMadder(t)
+	// Hook emits canonical ndjson-crap directly (one passing test record).
+	writeSweatfile(t, wtPath, "[hooks]\n"+
+		"pre-merge = \"echo '{\\\"type\\\":\\\"test\\\",\\\"n\\\":1,\\\"description\\\":\\\"synthetic\\\",\\\"ok\\\":true}'\"\n"+
+		"pre-merge-output-format = \"ndjson-crap\"\n")
+
+	var buf bytes.Buffer
+	links, err := Run(&buf, "tap", wtPath, false)
+	if err != nil {
+		t.Fatalf("Run() error: %v", err)
+	}
+	if len(links) != 1 || links[0].MimeType != "application/x-ndjson" {
+		t.Fatalf("expected one application/x-ndjson blob link, got %v", links)
+	}
+
+	got := buf.String()
+	if !strings.Contains(got, "format: ndjson-crap") {
+		t.Errorf("expected 'format: ndjson-crap' in output, got:\n%s", got)
+	}
+	if strings.Contains(got, "not ok") {
+		t.Errorf("did not expect 'not ok' on success, got:\n%s", got)
+	}
+	if strings.Contains(got, "tail:") || strings.Contains(got, "failure:") {
+		t.Errorf("did not expect tail/failure on success, got:\n%s", got)
+	}
+
+	// The blob stores the ndjson-crap stream verbatim (already canonical).
+	raw, _ := os.ReadFile(stdinCapture)
+	if !strings.Contains(string(raw), `"type":"test"`) || !strings.Contains(string(raw), "synthetic") {
+		t.Errorf("blob should contain the verbatim ndjson-crap record, got:\n%s", raw)
+	}
+}
+
+func TestRunHookCompactShape_NdjsonCrapFailure(t *testing.T) {
+	_, _, wtPath := setupRepoWithWorktree(t, "feature-ndjson-crap-failure")
+	withFakeMadder(t)
+	// Hook emits an ndjson-crap failing test record with a diagnostic, then
+	// exits non-zero.
+	writeSweatfile(t, wtPath, "[hooks]\n"+
+		"pre-merge = \"echo '{\\\"type\\\":\\\"test\\\",\\\"n\\\":1,\\\"description\\\":\\\"synthetic\\\",\\\"ok\\\":false,\\\"diagnostic\\\":{\\\"message\\\":\\\"expected 7 got 9\\\"}}'; exit 1\"\n"+
+		"pre-merge-output-format = \"ndjson-crap\"\n")
+
+	var buf bytes.Buffer
+	_, err := Run(&buf, "tap", wtPath, false)
+	if err == nil {
+		t.Fatalf("expected hook failure, got nil. Output: %s", buf.String())
+	}
+
+	got := buf.String()
+	if !strings.Contains(got, "not ok") {
+		t.Errorf("expected 'not ok' for failed hook, got:\n%s", got)
+	}
+	if !strings.Contains(got, "format: ndjson-crap") {
+		t.Errorf("expected 'format: ndjson-crap' in output, got:\n%s", got)
+	}
+	if !strings.Contains(got, "failure:") {
+		t.Errorf("expected 'failure:' field built from parsed crap records, got:\n%s", got)
+	}
+	if !strings.Contains(got, "expected 7 got 9") {
+		t.Errorf("expected diagnostic message in failure summary, got:\n%s", got)
+	}
+	if strings.Contains(got, "tail:") {
+		t.Errorf("did not expect 'tail:' when parsed records exist, got:\n%s", got)
+	}
+}
+
 func TestRunHookCompactShape_TapNDJSONDegenerateFallback(t *testing.T) {
 	_, _, wtPath := setupRepoWithWorktree(t, "feature-tap-ndjson-degenerate")
 	withFakeMadder(t)

--- a/internal/sweatfile/sweatfile.go
+++ b/internal/sweatfile/sweatfile.go
@@ -149,7 +149,7 @@ func (sf Sweatfile) InactivityTimeoutValue() time.Duration {
 
 // PreMergeOutputFormatValue returns the configured format for the
 // pre-merge hook's output, defaulting to "raw" when unset or empty.
-// Valid values: "raw", "tap-ndjson". Validation lives in
+// Valid values: "raw", "tap-ndjson", "ndjson-crap". Validation lives in
 // internal/validate.
 func (sf Sweatfile) PreMergeOutputFormatValue() string {
 	if sf.Hooks == nil || sf.Hooks.PreMergeOutputFormat == nil {

--- a/internal/validate/validate.go
+++ b/internal/validate/validate.go
@@ -175,8 +175,9 @@ func CheckStartCommands(sf sweatfile.Sweatfile) []Issue {
 }
 
 var validPreMergeOutputFormats = map[string]bool{
-	"raw":        true,
-	"tap-ndjson": true,
+	"raw":         true,
+	"tap-ndjson":  true,
+	"ndjson-crap": true,
 }
 
 // CheckHooks validates fields in the [hooks] table: the
@@ -191,7 +192,7 @@ func CheckHooks(sf sweatfile.Sweatfile) []Issue {
 		v := *sf.Hooks.PreMergeOutputFormat
 		if v != "" && !validPreMergeOutputFormats[v] {
 			issues = append(issues, Issue{
-				Message:  fmt.Sprintf("unknown pre-merge-output-format %q (valid: raw, tap-ndjson)", v),
+				Message:  fmt.Sprintf("unknown pre-merge-output-format %q (valid: raw, tap-ndjson, ndjson-crap)", v),
 				Severity: SeverityError,
 				Field:    "hooks.pre-merge-output-format",
 				Value:    v,


### PR DESCRIPTION
## Summary

Adds an `ndjson-crap` value to `[hooks].pre-merge-output-format` where the pre-merge hook emits **canonical ndjson-crap directly** and spinclass consumes it with **`crap/go-crap/ndjsoncrap.Reader`** — the ndjson-side consumer tracer for the crap extraction (complements cutting-garden's viewport tracer).

**Depends on amarbel-llc/crap#12** (the `crap/go-crap/ndjsoncrap` package).

No TAP→ndjson aggregation is needed on this path (the hook speaks the canonical format), so it uses crap's reader directly. The existing `tap-ndjson` path — which converts hook TAP-14 text via tap's aggregator — is left untouched; fully retiring it onto crap would require porting TAP-text ingest into crap, a separate follow-up.

## What changed

- `internal/check/check.go`: generalized the structured-format buffering (`tap-ndjson` | `ndjson-crap`) and added the `ndjson-crap` branch — parse the stream with `ndjsoncrap.Reader` for the failure summary, store it verbatim to madder (already canonical, no re-encode). New helpers `collectCrapTests` + `buildFailureSummaryCrap` (the ndjson-crap analogue of `buildFailureSummary`). `mimeTypeForFormat` maps `ndjson-crap` → `application/x-ndjson`.
- `internal/validate`: accept `ndjson-crap` in the format enum.
- Tests: `ndjson-crap` success + failure cases mirroring the tap-ndjson pair.

## Verification

- `go build ./...` green; `internal/check` + `internal/validate` tests green (29/30 packages).
- An **unrelated, pre-existing environmental flake** — `TestRunPreMergeHookContextInactivityKill` (a 10s watchdog-timing test) — fails in this sandbox **with or without these changes** (confirmed by stashing the change), so it is not a regression here.
- Dependency uses a dev `replace` to the sibling `../crap/go-crap` (the proxy only has the pre-viewport crap). ⚠️ **Productionizing for nix is a follow-up**: either `gomod2nix generate` once crap is published, or add a `goFlakeInputs` bridge. Drop the `replace` then.

https://claude.ai/code/session_01VFx1ioMv7C7JWt2MwfGccc

---
_Generated by [Claude Code](https://claude.ai/code/session_01VFx1ioMv7C7JWt2MwfGccc)_